### PR TITLE
Enable at, patch and synchronize tests

### DIFF
--- a/tests/integration/targets/at/aliases
+++ b/tests/integration/targets/at/aliases
@@ -1,3 +1,2 @@
 shippable/posix/group1
 destructive
-disabled # fixme package

--- a/tests/integration/targets/at/tasks/main.yml
+++ b/tests/integration/targets/at/tasks/main.yml
@@ -20,10 +20,11 @@
     msg: >-
       Skipping {{ ansible_distribution }} as ansible-base does not contain
       the packaging module ({{ ansible_pkg_mgr }}) for this operating system
+  when: ansible_pkg_mgr not in ['apt', 'dnf', 'yum'] or ansible_distribution in ['AIX']
 
 - name: stop executing on hosts that we don't have package manager modules for
   meta: end_host
-  when: ansible_pkg_mgr not in ['apt', 'dnf', 'yum']
+  when: ansible_pkg_mgr not in ['apt', 'dnf', 'yum'] or ansible_distribution in ['AIX']
 
 - set_fact: output_dir_test={{output_dir}}/at
 

--- a/tests/integration/targets/at/tasks/main.yml
+++ b/tests/integration/targets/at/tasks/main.yml
@@ -16,34 +16,36 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- debug:
+    msg: >-
+      Skipping {{ ansible_distribution }} as ansible-base does not contain
+      the packaging module ({{ ansible_pkg_mgr }}) for this operating system
+
+- name: stop executing on hosts that we don't have package manager modules for
+  meta: end_host
+  when: ansible_pkg_mgr not in ['apt', 'dnf', 'yum']
+
 - set_fact: output_dir_test={{output_dir}}/at
 
 - name: make sure our testing sub-directory does not exist
-  file: path="{{ output_dir_test }}" state=absent
+  file:
+    path: "{{ output_dir_test }}"
+    state: absent
 
 - name: create our testing sub-directory
-  file: path="{{ output_dir_test }}" state=directory
+  file:
+    path: "{{ output_dir_test }}"
+    state: directory
 
 ##
 ## at
 ##
 
-- name: define distros to attempt installing at on 
-  set_fact:
-    package_distros:
-        - RedHat
-        - CentOS
-        - ScientificLinux
-        - Fedora
-        - Ubuntu
-        - Debian
-        - openSUSE Leap
-
 - name: ensure at is installed
   package:
     name: at
     state: present
-  when: ansible_distribution in package_distros
+  when: ansible_pkg_mgr in ['apt', 'dnf', 'yum']
 
 - name: run the first example
   at:

--- a/tests/integration/targets/patch/aliases
+++ b/tests/integration/targets/patch/aliases
@@ -1,4 +1,3 @@
 destructive
 shippable/posix/group1
 skip/aix
-disabled # fixme package

--- a/tests/integration/targets/patch/tasks/main.yml
+++ b/tests/integration/targets/patch/tasks/main.yml
@@ -1,12 +1,3 @@
-# - debug:
-#     msg: >-
-#       Skipping {{ ansible_distribution }} as ansible-base does not contain
-#       the packaging module ({{ ansible_pkg_mgr }}) for this operating system
-# 
-# - name: stop executing on hosts that we don't have package manager modules for
-#   meta: end_host
-#   when: ansible_pkg_mgr not in ['apt', 'dnf', 'yum']
-
 - name: ensure idempotency installed
   package:
     name: patch

--- a/tests/integration/targets/patch/tasks/main.yml
+++ b/tests/integration/targets/patch/tasks/main.yml
@@ -2,6 +2,7 @@
     msg: >-
       Skipping {{ ansible_distribution }} as ansible-base does not contain
       the packaging module ({{ ansible_pkg_mgr }}) for this operating system
+  when: ansible_pkg_mgr not in ['apt', 'dnf', 'yum']
 
 - name: stop executing on hosts that we don't have package manager modules for
   meta: end_host

--- a/tests/integration/targets/patch/tasks/main.yml
+++ b/tests/integration/targets/patch/tasks/main.yml
@@ -1,3 +1,12 @@
+- debug:
+    msg: >-
+      Skipping {{ ansible_distribution }} as ansible-base does not contain
+      the packaging module ({{ ansible_pkg_mgr }}) for this operating system
+
+- name: stop executing on hosts that we don't have package manager modules for
+  meta: end_host
+  when: ansible_pkg_mgr not in ['apt', 'dnf', 'yum']
+
 - name: ensure idempotency installed
   package:
     name: patch

--- a/tests/integration/targets/patch/tasks/main.yml
+++ b/tests/integration/targets/patch/tasks/main.yml
@@ -1,55 +1,75 @@
+# - debug:
+#     msg: >-
+#       Skipping {{ ansible_distribution }} as ansible-base does not contain
+#       the packaging module ({{ ansible_pkg_mgr }}) for this operating system
+# 
+# - name: stop executing on hosts that we don't have package manager modules for
+#   meta: end_host
+#   when: ansible_pkg_mgr not in ['apt', 'dnf', 'yum']
+
 - name: ensure idempotency installed
   package:
     name: patch
-  when: ansible_distribution != "MacOSX"
+  when: ansible_pkg_mgr in ['apt', 'dnf', 'yum']
+
 - name: create a directory for the result
   file:
     dest: '{{ output_dir }}/patch'
     state: directory
   register: result
+
 - name: assert the directory was created
   assert:
     that:
     - result.state == 'directory'
+
 - name: copy the origin file
   copy:
     src: ./origin.txt
     dest: '{{ output_dir }}/patch/workfile.txt'
   register: result
+
 - name: patch the origin file in check mode
   check_mode: true
   register: result
   patch:
     src: result.patch
     dest: '{{ output_dir }}/patch/workfile.txt'
+
 - name: verify patch the origin file in check mode
   assert:
     that:
     - result is changed
+
 - name: patch the origin file
   register: result
   patch:
     src: result.patch
     dest: '{{ output_dir }}/patch/workfile.txt'
+
 - name: verify patch the origin file
   assert:
     that:
     - result is changed
+
 - name: test patch the origin file idempotency
   register: result
   patch:
     src: result.patch
     dest: '{{ output_dir }}/patch/workfile.txt'
+
 - name: verify test patch the origin file idempotency
   assert:
     that:
     - result is not changed
+
 - name: verify the resulted file matches expectations
   copy:
     src: ./result.txt
     dest: '{{ output_dir }}/patch/workfile.txt'
   register: result
   failed_when: result is changed
+
 - name: patch the workfile file in check mode state absent
   check_mode: true
   register: result
@@ -57,30 +77,36 @@
     src: result.patch
     dest: '{{ output_dir }}/patch/workfile.txt'
     state: absent
+
 - name: verify patch the workfile file in check mode state absent
   assert:
     that:
     - result is changed
+
 - name: patch the workfile file state absent
   register: result
   patch:
     src: result.patch
     dest: '{{ output_dir }}/patch/workfile.txt'
     state: absent
+
 - name: verify patch the workfile file state absent
   assert:
     that:
     - result is changed
+
 - name: patch the workfile file state absent idempotency
   register: result
   patch:
     src: result.patch
     dest: '{{ output_dir }}/patch/workfile.txt'
     state: absent
+
 - name: verify patch the workfile file state absent idempotency
   assert:
     that:
     - result is not changed
+
 - name: verify the resulted file matches expectations
   copy:
     src: ./origin.txt

--- a/tests/integration/targets/synchronize/aliases
+++ b/tests/integration/targets/synchronize/aliases
@@ -1,2 +1,1 @@
 shippable/posix/group1
-disabled # fixme package

--- a/tests/integration/targets/synchronize/tasks/main.yml
+++ b/tests/integration/targets/synchronize/tasks/main.yml
@@ -1,7 +1,8 @@
 - name: install rsync
   package:
     name: rsync
-  when: ansible_distribution != "MacOSX"
+  when: ansible_pkg_mgr in ['apt', 'dnf', 'yum']
+
 - name: cleanup old files
   shell: rm -rf {{output_dir}}/*
 - name: create test new files

--- a/tests/integration/targets/synchronize/tasks/main.yml
+++ b/tests/integration/targets/synchronize/tasks/main.yml
@@ -2,6 +2,7 @@
     msg: >-
       Skipping {{ ansible_distribution }} as ansible-base does not contain
       the packaging module ({{ ansible_pkg_mgr }}) for this operating system
+  when: ansible_pkg_mgr not in ['apt', 'dnf', 'yum']
 
 - name: stop executing on hosts that we don't have package manager modules for
   meta: end_host

--- a/tests/integration/targets/synchronize/tasks/main.yml
+++ b/tests/integration/targets/synchronize/tasks/main.yml
@@ -1,3 +1,12 @@
+- debug:
+    msg: >-
+      Skipping {{ ansible_distribution }} as ansible-base does not contain
+      the packaging module ({{ ansible_pkg_mgr }}) for this operating system
+
+- name: stop executing on hosts that we don't have package manager modules for
+  meta: end_host
+  when: ansible_pkg_mgr not in ['apt', 'dnf', 'yum']
+
 - name: install rsync
   package:
     name: rsync


### PR DESCRIPTION
##### SUMMARY
Updates tests to either skip completely when `ansible_pkg_mgr` isn't one of the base package managers, or just skip `package` tasks in the same scenario.

`at` isn't universally installed it seems, so that one is skipped completed on unsupported targets.

See https://github.com/ansible-collections/ansible.posix/issues/3

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
