### PR TITLE
Mount fixes

### DIFF
--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -716,9 +716,6 @@ def main():
 
             changed = True
     elif state == 'mounted':
-        if not os.path.exists(args['src']):
-            module.fail_json(msg="Unable to mount %s as it does not exist" % args['src'])
-
         if not os.path.exists(name) and not module.check_mode:
             try:
                 os.makedirs(name)

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -153,13 +153,14 @@ EXAMPLES = r'''
 '''
 
 
+import errno
 import os
 import platform
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.posix.plugins.module_utils.ismount import ismount
 from ansible.module_utils.six import iteritems
-from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_bytes, to_native
 
 
 def write_fstab(module, lines, path):
@@ -195,8 +196,15 @@ def _escape_fstab(v):
 
 def set_mount(module, args):
     """Set/change a mount point location in fstab."""
+    name, backup_lines, changed = _set_mount_save_old(module, args)
+    return name, changed
+
+
+def _set_mount_save_old(module, args):
+    """Set/change a mount point location in fstab. Save the old fstab contents."""
 
     to_write = []
+    old_lines = []
     exists = False
     changed = False
     escaped_args = dict([(k, _escape_fstab(v)) for k, v in iteritems(args)])
@@ -207,6 +215,8 @@ def set_mount(module, args):
             '%(src)s - %(name)s %(fstype)s %(passno)s %(boot)s %(opts)s\n')
 
     for line in open(args['fstab'], 'r').readlines():
+        old_lines.append(line)
+
         if not line.strip():
             to_write.append(line)
 
@@ -289,7 +299,7 @@ def set_mount(module, args):
     if changed and not module.check_mode:
         write_fstab(module, to_write, args['fstab'])
 
-    return (args['name'], changed)
+    return (args['name'], old_lines, changed)
 
 
 def unset_mount(module, args):
@@ -716,14 +726,34 @@ def main():
 
             changed = True
     elif state == 'mounted':
+        dirs_created = []
         if not os.path.exists(name) and not module.check_mode:
             try:
-                os.makedirs(name)
+                # Something like mkdir -p but with the possibility to undo.
+                # Based on some copy-paste from the "file" module.
+                curpath = ''
+                for dirname in name.strip('/').split('/'):
+                    curpath = '/'.join([curpath, dirname])
+                    # Remove leading slash if we're creating a relative path
+                    if not os.path.isabs(name):
+                        curpath = curpath.lstrip('/')
+
+                    b_curpath = to_bytes(curpath, errors='surrogate_or_strict')
+                    if not os.path.exists(b_curpath):
+                        try:
+                            os.mkdir(b_curpath)
+                            dirs_created.append(b_curpath)
+                        except OSError as ex:
+                            # Possibly something else created the dir since the os.path.exists
+                            # check above. As long as it's a dir, we don't need to error out.
+                            if not (ex.errno == errno.EEXIST and os.path.isdir(b_curpath)):
+                                raise
+
             except (OSError, IOError) as e:
                 module.fail_json(
                     msg="Error making dir %s: %s" % (name, to_native(e)))
 
-        name, changed = set_mount(module, args)
+        name, backup_lines, changed = _set_mount_save_old(module, args)
         res = 0
 
         if (
@@ -740,6 +770,21 @@ def main():
                 res, msg = mount(module, args)
 
         if res:
+            # Not restoring fstab after a failed mount was reported as a bug,
+            # ansible/ansible#59183
+            # A non-working fstab entry may break the system at the reboot,
+            # so undo all the changes if possible.
+            try:
+                write_fstab(module, backup_lines, args['fstab'])
+            except Exception:
+                pass
+
+            try:
+                for dirname in dirs_created[::-1]:
+                    os.rmdir(dirname)
+            except Exception:
+                pass
+
             module.fail_json(msg="Error mounting %s: %s" % (name, msg))
     elif state == 'present':
         name, changed = set_mount(module, args)

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -32,7 +32,7 @@ options:
     aliases: [ name ]
   src:
     description:
-      - Device to be mounted on I(path).
+      - Device (or NFS volume, or something else) to be mounted on I(path).
       - Required when I(state) set to C(present) or C(mounted).
     type: path
   fstype:


### PR DESCRIPTION
##### SUMMARY
This is a resubmission of ansible/ansible#65869, which became necessary after splitting off the ansible.posix collection. Please apply ansible/ansible#68223 first.

The history is:

* a bug (ansible/ansible#59183) was reported that a broken fstab entry remains after a failed mount;
* an attempt to fix that bug was made by @Akasurde (ansible/ansible#61752), but it completely broke mounting of network shares (ansible/ansible#65855 and ansible/ansible#67966), as well as UUID-based mounts (ansible/ansible#67588), while still leaving cases (e.g. bad mount options) where a broken fstab entry remains on the system.

Therefore, this pull request reverts the bad fix and implements a hopefully better one, by letting the doomed mount fail and then dealing with the consequences (undoing the fstab line and directory creation).

In ansible/ansible#68102 @Akasurde confirmed that the bad fix needs to be reverted. In ansible/ansible#65869 there was a promise to test the new code, but so far it didn't materialize, and cannot materialize without ansible/ansible#68223.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mount

##### ADDITIONAL INFORMATION

See more discussion here: ansible/ansible#68155, ansible/ansible#68102, ansible/ansible#65544, ansible/ansible#65869.

Test cases:

```
# Should succeed assuming that /dev/sdb1 indeed contains xfs
ansible -i hosts myserver --become -m mount -a 'src=/dev/sdb1 path=/mnt/local state=mounted fstype=xfs'

# Should also work, was broken before the change
# "Unable to mount 192.168.0.1:/mnt/bigdisk as it does not exist"
ansible -i hosts myserver --become -m mount -a 'src=192.168.0.1:/mnt/bigdisk path=/mnt/big state=mounted fstype=nfs'

# Should fail without changing /etc/fstab and without leaving /mnt/bad
ansible -i hosts myserver --become -m mount -a 'src=/dev/sdb1 path=/mnt/bad state=mounted fstype=ext4'
```