### PR TITLE
Copy and adjust changes from ansible/ansible#59530

### DIFF
--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -262,6 +262,22 @@
     fail:
       msg: Filesytem was not remounted, testing of the module failed!
     when: last_write is defined and last_write_time2 is defined and last_write_time.stdout == last_write_time2.stdout and ansible_system in ('Linux')
+  - name: Remount filesystem with different opts using remounted option (Linux only)
+    mount:
+      path: /tmp/myfs
+      state: remounted
+      opts: rw,noexec
+    when: ansible_system == 'Linux'
+  - name: Get remounted options (Linux only)
+    shell: mount | grep myfs | grep -E -w 'noexec' | wc -l
+    register: remounted_options
+    when: ansible_system == 'Linux'
+  - name: Make sure the filesystem now has the new opts after using remounted (Linux only)
+    assert:
+      that:
+        - "'1' in remounted_options.stdout"
+        - "1 == remounted_options.stdout_lines | length"
+    when: ansible_system == 'Linux'
   always:
   - name: Umount the test FS
     mount:


### PR DESCRIPTION
##### SUMMARY

Goal: Handle remount with new options.  This ensures that people can use the ansible version of `mount -o remount,exec /tmp` as expected for temporary changed in the mounting options without changing the `fstab`.

Fixes ansible/ansible#59460

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME

mount

##### ADDITIONAL INFORMATION

Without change:
```
remote $ grep ' /tmp' /etc/fstab
/dev/mapper/vg_workstation-lv_tmp /tmp ext4 nosuid,nodev,noexec,defaults        0       2

remote $ mount | grep /tmp
/dev/mapper/vg_workstation-lv_tmp on /tmp type ext4 (rw,nosuid,nodev,noexec,relatime,data=ordered)

controller $ ansible all -i "[REDACTED]," -m mount -a 'path=/tmp state=remounted opts=exec' --user [REDACTED] --ask-pass --become --ask-become-pass --become-user root
[REDACTED] | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "dump": "0",
    "fstab": "/etc/fstab",
    "name": "/tmp",
    "opts": "exec",
    "passno": "0"
}

remote $ grep ' /tmp' /etc/fstab
/dev/mapper/vg_workstation-lv_tmp /tmp ext4 nosuid,nodev,noexec,defaults        0       2

remote $ mount | grep /tmp
/dev/mapper/vg_workstation-lv_tmp on /tmp type ext4 (rw,nosuid,nodev,noexec,relatime,data=ordered)
```



With change:
```
remote $ grep ' /tmp' /etc/fstab
/dev/mapper/vg_workstation-lv_tmp /tmp ext4 nosuid,nodev,noexec,defaults        0       2

remote $ mount | grep /tmp
/dev/mapper/vg_workstation-lv_tmp on /tmp type ext4 (rw,nosuid,nodev,noexec,relatime,data=ordered)

controller $ ansible all -i "[REDACTED]," -m mount -a 'path=/tmp state=remounted opts=exec' --user [REDACTED] --ask-pass --become --ask-become-pass --become-user root
[REDACTED] | CHANGED => {
    "ansible_facts": {
        "discovered_interpreter_python": "/usr/bin/python"
    },
    "changed": true,
    "dump": "0",
    "fstab": "/etc/fstab",
    "name": "/tmp",
    "opts": "exec",
    "passno": "0"
}

remote $ grep ' /tmp' /etc/fstab
/dev/mapper/vg_workstation-lv_tmp /tmp ext4 nosuid,nodev,noexec,defaults        0       2

remote $ mount | grep /tmp
/dev/mapper/vg_workstation-lv_tmp on /tmp type ext4 (rw,nosuid,nodev,relatime,data=ordered)
```

Continuation of ansible/ansible#59530