### PR TITLE
Fix issue ansible/ansible#59059

### DIFF
--- a/plugins/callback/profile_tasks.py
+++ b/plugins/callback/profile_tasks.py
@@ -172,7 +172,7 @@ class CallbackModule(CallbackBase):
         timestamp(self)
         self.current = None
 
-        results = self.stats.items()
+        results = list(self.stats.items())
 
         # Sort the tasks by the specified sort
         if self.sort_order is not None:


### PR DESCRIPTION
#### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix issue ansible/ansible#59059
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

When no sorting was selected, `result` was a `odict_items` which is not subscriptable, so the slicing was failing.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
profile_tasks

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:
```shell
export ANSIBLE_CALLBACK_WHITELIST=ansible.posix.profile_tasks
export PROFILE_TASKS_SORT_ORDER=none
ansible-playbook playbook.yml  # with any playbook, a simple one doing a ping is enough
# ...
[WARNING]: Failure using method (v2_playbook_on_stats) in callback plugin (<ansible_collections.ansible.posix.plugins.callback.profile_tasks.CallbackModule object at 0x7fa51ef37d90>): 'odict_items' object is not subscriptable
```
After:
```shell
export ANSIBLE_CALLBACK_WHITELIST=ansible.posix.profile_tasks
export PROFILE_TASKS_SORT_ORDER=none
ansible-playbook playbook.yml
# ...
Gathering Facts ---------------------------------------------------- 0.90s
ping --------------------------------------------------------------- 0.24s
```