### PR TITLE
Typecast results before use in profile_tasks callback

### DIFF
--- a/plugins/callback/profile_tasks.py
+++ b/plugins/callback/profile_tasks.py
@@ -46,7 +46,7 @@ EXAMPLES = '''
 example: >
   To enable, add this to your ansible.cfg file in the defaults block
     [defaults]
-    callback_whitelist = profile_tasks
+    callback_whitelist = ansible.posix.profile_tasks
 sample output: >
 #
 #    TASK: [ensure messaging security group exists] ********************************
@@ -183,7 +183,7 @@ class CallbackModule(CallbackBase):
             )
 
         # Display the number of tasks specified or the default of 20
-        results = results[:self.task_output_limit]
+        results = list(results)[:self.task_output_limit]
 
         # Print the timings
         for uuid, result in results:


### PR DESCRIPTION
##### SUMMARY

If user specifies sort_order to none, results are not converted to list.
This fix force this typecasting before using the results.

Fixes: https://github.com/ansible/ansible/issues/69563

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/callback/profile_tasks.py
