### PR TITLE
Updates authorized_key.py to be used with FIDO2 security keys.

### DIFF
--- a/changelogs/fragments/17_authorized_keys.yml
+++ b/changelogs/fragments/17_authorized_keys.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- authorized_keys - Added FIDO2 security keys (https://github.com/ansible-collections/ansible.posix/issues/17).

--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -386,13 +386,14 @@ def parsekey(module, raw_key, rank=None):
     '''
 
     VALID_SSH2_KEY_TYPES = [
-        'ssh-ed25519',
+        'sk-ecdsa-sha2-nistp256@openssh.com',
         'ecdsa-sha2-nistp256',
         'ecdsa-sha2-nistp384',
         'ecdsa-sha2-nistp521',
+        'sk-ssh-ed25519@openssh.com',
+        'ssh-ed25519',
         'ssh-dss',
         'ssh-rsa',
-        'sk-ecdsa-sha2-nistp256@openssh.com',
     ]
 
     options = None   # connection options

--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -392,6 +392,7 @@ def parsekey(module, raw_key, rank=None):
         'ecdsa-sha2-nistp521',
         'ssh-dss',
         'ssh-rsa',
+        'sk-ecdsa-sha2-nistp256@openssh.com',
     ]
 
     options = None   # connection options


### PR DESCRIPTION
Last try had a space at the end for some weird reason.
