### PR TITLE
Synchronize plugin: Do not turn an SSH path into an absolute path

### DIFF
--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -33,7 +33,7 @@ class ActionModule(ActionBase):
     def _get_absolute_path(self, path):
         original_path = path
 
-        if path.startswith('rsync://') or path.startswith('/') or ':' in path:
+        if path.startswith(('rsync://', '/')) or ':' in path:
             return path
 
         if self._task._role is not None:

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -33,7 +33,7 @@ class ActionModule(ActionBase):
     def _get_absolute_path(self, path):
         original_path = path
 
-        if path.startswith('rsync://'):
+        if path.startswith('rsync://') or path.startswith('/') or ':' in path:
             return path
 
         if self._task._role is not None:
@@ -73,8 +73,7 @@ class ActionModule(ActionBase):
         if host not in C.LOCALHOST:
             return self._format_rsync_rsh_target(host, path, user)
 
-        if ':' not in path and not path.startswith('/'):
-            path = self._get_absolute_path(path=path)
+        path = self._get_absolute_path(path=path)
         return path
 
     def _process_remote(self, task_args, host, path, user, port_matches_localhost_port):
@@ -103,8 +102,7 @@ class ActionModule(ActionBase):
                 task_args['_substitute_controller'] = True
             return self._format_rsync_rsh_target(host, path, user)
 
-        if ':' not in path and not path.startswith('/'):
-            path = self._get_absolute_path(path=path)
+        path = self._get_absolute_path(path=path)
         return path
 
     def _override_module_replaced_vars(self, task_vars):
@@ -350,10 +348,8 @@ class ActionModule(ActionBase):
         else:
             # Still need to munge paths (to account for roles) even if we aren't
             # copying files between hosts
-            if not src.startswith('/'):
-                src = self._get_absolute_path(path=src)
-            if not dest.startswith('/'):
-                dest = self._get_absolute_path(path=dest)
+            src = self._get_absolute_path(path=src)
+            dest = self._get_absolute_path(path=dest)
 
         _tmp_args['src'] = src
         _tmp_args['dest'] = dest


### PR DESCRIPTION
##### SUMMARY
SSH paths of the form user@host:/remote/path can be used as either src or dest with rsync.
However, the path is turned into /local/path/user@host:/remote/path, which is not a valid syntax for rsync. This commit fixes that problem.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
synchronize action plugin

##### ADDITIONAL INFORMATION
As the synchronize module already uses the presence of ':' to detect a source/destination over SSH, this commit updates the action plugin accordingly.