### PR TITLE
Remove version from galaxy.yml

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,5 @@
 namespace: ansible
 name: posix
-version: 0.1.1
 readme: README.md
 authors:
   - Ansible (github.com/ansible)


### PR DESCRIPTION
We inject the version string at runtime, so we can remove the hardcoded
number.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>