### PR TITLE
Bump version to 0.1.2

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: ansible
 name: posix
-version: 0.1.1
+version: 0.1.2
 readme: README.md
 authors:
   - Ansible (github.com/ansible)


### PR DESCRIPTION
We need to do this manually, as some tests are still in shippable.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>