### PR TITLE
selinux - add missing config keys when needed

### DIFF
--- a/changelogs/.gitignore
+++ b/changelogs/.gitignore
@@ -1,0 +1,1 @@
+/.plugin-cache.yaml

--- a/changelogs/.gitignore
+++ b/changelogs/.gitignore
@@ -1,1 +1,0 @@
-/.plugin-cache.yaml

--- a/changelogs/fragments/23-selinux-doesnt-create-missing-config-keys
+++ b/changelogs/fragments/23-selinux-doesnt-create-missing-config-keys
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - selinux - add missing configuration keys for /etc/selinux/config (https://github.com/ansible-collections/ansible.posix/issues/23)

--- a/plugins/modules/selinux.py
+++ b/plugins/modules/selinux.py
@@ -125,8 +125,14 @@ def set_config_state(module, state, configfile):
     tmpfd, tmpfile = tempfile.mkstemp()
 
     with open(tmpfile, "w") as write_file:
+        line_found = False
         for line in lines:
+            if re.match(r'^SELINUX=.*$', line):
+                line_found = True
             write_file.write(re.sub(r'^SELINUX=.*', stateline, line) + '\n')
+
+        if not line_found:
+            write_file.write('SELINUX=%s\n' % state)
 
     module.atomic_move(tmpfile, configfile)
 
@@ -155,8 +161,14 @@ def set_config_policy(module, policy, configfile):
     tmpfd, tmpfile = tempfile.mkstemp()
 
     with open(tmpfile, "w") as write_file:
+        line_found = False
         for line in lines:
+            if re.match(r'^SELINUXTYPE=.*$', line):
+                line_found = True
             write_file.write(re.sub(r'^SELINUXTYPE=.*', policyline, line) + '\n')
+
+        if not line_found:
+            write_file.write('SELINUXTYPE=%s\n' % policy)
 
     module.atomic_move(tmpfile, configfile)
 

--- a/tests/integration/targets/selinux/tasks/selinux.yml
+++ b/tests/integration/targets/selinux/tasks/selinux.yml
@@ -362,3 +362,79 @@
       - (_check_mode_test5.warnings | length ) >= 1
       - ansible_selinux.config_mode == 'disabled'
       - ansible_selinux.type == 'targeted'
+
+# Fifth Test
+# ##############################################################################
+# Remove SELINUX and SELINUXTYPE keys from /etc/selinux/config and make
+# sure the module re-adds the expected lines
+
+- name: TEST 5 | Remove SELINUX key from /etc/selinux/config
+  lineinfile:
+    path: /etc/selinux/config
+    regexp: '^SELINUX='
+    state: absent
+    backup: yes
+  register: _lineinfile_out1
+
+- debug:
+    var: _lineinfile_out1
+    verbosity: 1
+
+- name: TEST 5 | Set SELinux to enforcing 
+  selinux:
+    state: enforcing
+    policy: targeted
+  register: _set_enforcing1
+
+- name: TEST 5 | Re-gather facts
+  setup:
+
+- debug:
+    var: ansible_selinux
+    verbosity: 1
+
+- name: TEST 5 | Assert that SELINUX key is populated
+  assert:
+    that:
+      - _set_enforcing1 is success
+      - _set_enforcing1 is changed
+      - _set_enforcing1.state == 'enforcing'
+      - ansible_selinux.config_mode == 'enforcing'
+
+- name: TEST 5 | Remove SELINUXTYPE key from /etc/selinux/config
+  lineinfile:
+    path: /etc/selinux/config
+    regexp: '^SELINUXTYPE='
+    state: absent
+  register: _lineinfile_out2
+
+- debug:
+    var: _lineinfile_out2
+    verbosity: 1
+
+- name: TEST 5 | Set SELinux Policy to targeted
+  selinux:
+    state: enforcing
+    policy: targeted
+  register: _set_policy2
+
+- name: TEST 5 | Re-gather facts
+  setup:
+
+- debug:
+    var: ansible_selinux
+    verbosity: 1
+
+- name: TEST 5 | Assert that SELINUXTYPE key is populated
+  assert:
+    that:
+      - _set_policy2 is success
+      - _set_policy2 is changed
+      - _set_policy2.policy == 'targeted'
+      - ansible_selinux.type == 'targeted'
+
+- name: TEST 5 | Restore original SELinux config file /etc/selinux/config
+  copy:
+    dest: /etc/selinux/config
+    src: "{{ _lineinfile_out1['backup'] }}"
+    remote_src: yes


### PR DESCRIPTION
##### SUMMARY

Previously the selinux module would only edit the state of found
configuration keys SELINUX and SELINUXTYPE in /etc/selinux/config but
would not add them with desired state if they were not found.

Fixes #23

https://github.com/ansible-collections/ansible.posix/issues/23

Signed-off-by: Adam Miller <admiller@redhat.com>

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
selinux

