### PR TITLE
authorized_keys - consistent behavior in check_mode

### DIFF
--- a/changelogs/fragments/37-authorized_keys-inconsistent-check-mode-values.yml
+++ b/changelogs/fragments/37-authorized_keys-inconsistent-check-mode-values.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - authorized_keys - fix inconsistent return value for check mode (https://github.com/ansible-collections/ansible.posix/issues/37)

--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -635,13 +635,9 @@ def enforce_state(module, params):
             }
             params['diff'] = diff
 
-        if module.check_mode:
-            module.exit_json(changed=True, diff=diff)
-        writefile(module, filename, new_content)
+        if not module.check_mode:
+            writefile(module, filename, new_content)
         params['changed'] = True
-    else:
-        if module.check_mode:
-            module.exit_json(changed=False)
 
     return params
 

--- a/tests/integration/targets/authorized_key/tasks/main.yml
+++ b/tests/integration/targets/authorized_key/tasks/main.yml
@@ -410,12 +410,13 @@
 # -------------------------------------------------------------
 # check mode
 
-- name: copy an existing file in place with comments
+- name: CHECK MODE | copy an existing file in place with comments
   copy:
     src: existing_authorized_keys
     dest: "{{ output_dir | expanduser }}/authorized_keys"
 
-- authorized_key:
+- name: CHECK MODE | add key in check mode to validate return codes
+  authorized_key:
     user: root
     key: "{{ multiple_key_different_order_2 }}"
     state: present
@@ -423,13 +424,21 @@
   check_mode: True
   register: result
 
-- name: assert that the file was not changed
+- name: CHECK MODE | assert that authorized_keys return values are consistent
+  assert:
+    that:
+      - 'result.changed == True'
+      - '"user" in result'
+      - '"key" in result'
+
+- name: CHECK MODE | recopy authorized_keys to ensure it was not changed 
   copy:
     src: existing_authorized_keys
     dest: "{{ output_dir | expanduser }}/authorized_keys"
   register: result
 
-- assert:
+- name: CHECK MODE | assert that the authorized_keys file was not changed
+  assert:
     that:
       - 'result.changed == False'
 


### PR DESCRIPTION
##### SUMMARY
Previously check_mode would incorrectly return changed=False even when a
change would have taken place if ran without check_mode, with
integration tests that confirmed this incorrect behavior. Also the
module did not correctly populate the return values when run in
check_mode. Both of these issues are resolved in this PR.

Fixes https://github.com/ansible-collections/ansible.posix/issues/37

Signed-off-by: Adam Miller <admiller@redhat.com>

<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.posix.authorized_keys

