### PR TITLE
remove references to old default branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ansible.posix
 <!-- Add CI and code coverage badges here. Samples included below. -->
-[![Run Status](https://api.shippable.com/projects/5e669aaf8b17a60007e4d18d/badge?branch=master)]() <!--[![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/ansible.posix)](https://codecov.io/gh/ansible-collections/ansible.posix)-->
+[![Run Status](https://api.shippable.com/projects/5e669aaf8b17a60007e4d18d/badge?branch=main)]() <!--[![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/ansible.posix)](https://codecov.io/gh/ansible-collections/ansible.posix)-->
 
 <!-- Describe the collection and why a user would want to use it. What does the collection do? -->
 An Ansible Collection of modules and plugins that target POSIX UNIX/Linux and derivative Operating Systems.
@@ -22,15 +22,15 @@ PEP440 is the schema used to describe the versions of Ansible.
 ### Modules
 Name | Description
 --- | ---
-[ansible.posix.acl](https://github.com/ansible-collections/ansible.posix/blob/master/docs/ansible.posix.acl_module.rst)|Set and retrieve file ACL information.
-[ansible.posix.at](https://github.com/ansible-collections/ansible.posix/blob/master/docs/ansible.posix.at_module.rst)|Schedule the execution of a command or script file via the at command
-[ansible.posix.authorized_key](https://github.com/ansible-collections/ansible.posix/blob/master/docs/ansible.posix.authorized_key_module.rst)|Adds or removes an SSH authorized key
-[ansible.posix.mount](https://github.com/ansible-collections/ansible.posix/blob/master/docs/ansible.posix.mount_module.rst)|Control active and configured mount points
-[ansible.posix.patch](https://github.com/ansible-collections/ansible.posix/blob/master/docs/ansible.posix.patch_module.rst)|Apply patch files using the GNU patch tool
-[ansible.posix.seboolean](https://github.com/ansible-collections/ansible.posix/blob/master/docs/ansible.posix.seboolean_module.rst)|Toggles SELinux booleans
-[ansible.posix.selinux](https://github.com/ansible-collections/ansible.posix/blob/master/docs/ansible.posix.selinux_module.rst)|Change policy and state of SELinux
-[ansible.posix.synchronize](https://github.com/ansible-collections/ansible.posix/blob/master/docs/ansible.posix.synchronize_module.rst)|A wrapper around rsync to make common tasks in your playbooks quick and easy
-[ansible.posix.sysctl](https://github.com/ansible-collections/ansible.posix/blob/master/docs/ansible.posix.sysctl_module.rst)|Manage entries in sysctl.conf.
+[ansible.posix.acl](https://github.com/ansible-collections/ansible.posix/blob/main/docs/ansible.posix.acl_module.rst)|Set and retrieve file ACL information.
+[ansible.posix.at](https://github.com/ansible-collections/ansible.posix/blob/main/docs/ansible.posix.at_module.rst)|Schedule the execution of a command or script file via the at command
+[ansible.posix.authorized_key](https://github.com/ansible-collections/ansible.posix/blob/main/docs/ansible.posix.authorized_key_module.rst)|Adds or removes an SSH authorized key
+[ansible.posix.mount](https://github.com/ansible-collections/ansible.posix/blob/main/docs/ansible.posix.mount_module.rst)|Control active and configured mount points
+[ansible.posix.patch](https://github.com/ansible-collections/ansible.posix/blob/main/docs/ansible.posix.patch_module.rst)|Apply patch files using the GNU patch tool
+[ansible.posix.seboolean](https://github.com/ansible-collections/ansible.posix/blob/main/docs/ansible.posix.seboolean_module.rst)|Toggles SELinux booleans
+[ansible.posix.selinux](https://github.com/ansible-collections/ansible.posix/blob/main/docs/ansible.posix.selinux_module.rst)|Change policy and state of SELinux
+[ansible.posix.synchronize](https://github.com/ansible-collections/ansible.posix/blob/main/docs/ansible.posix.synchronize_module.rst)|A wrapper around rsync to make common tasks in your playbooks quick and easy
+[ansible.posix.sysctl](https://github.com/ansible-collections/ansible.posix/blob/main/docs/ansible.posix.sysctl_module.rst)|Manage entries in sysctl.conf.
 
 <!--end collection content-->
 

--- a/docs/ansible.posix.patch_module.rst
+++ b/docs/ansible.posix.patch_module.rst
@@ -122,7 +122,7 @@ Parameters
                                                                                     </ul>
                                                                             </td>
                                                                 <td>
-                                            <div>If <code>no</code>, it will search for src at originating/master machine, if <code>yes</code> it will go to the remote/target machine for the <code>src</code>.</div>
+                                            <div>If <code>no</code>, it will search for src at originating/controller machine, if <code>yes</code> it will go to the remote/target machine for the <code>src</code>.</div>
                                                         </td>
             </tr>
                                 <tr>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,6 +9,6 @@ license_file: COPYING
 tags: [posix, networking, shell, unix]
 dependencies: {}
 repository: https://github.com/ansible-collections/ansible.posix
-documentation: https://github.com/ansible-collections/ansible.posix/tree/master/docs
+documentation: https://github.com/ansible-collections/ansible.posix/tree/main/docs
 homepage: https://github.com/ansible-collections/ansible.posix
 issues: https://github.com/ansible-collections/ansible.posix

--- a/plugins/modules/patch.py
+++ b/plugins/modules/patch.py
@@ -50,7 +50,7 @@ options:
     default: present
   remote_src:
     description:
-      - If C(no), it will search for src at originating/master machine, if C(yes) it will
+      - If C(no), it will search for src at originating/controller machine, if C(yes) it will
         go to the remote/target machine for the C(src).
     type: bool
     default: no


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
remove references to old default branch name
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.posix

```
