### PR TITLE
disable AIX tests in shippable for now because of intermittent failures from IBM Cloud

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -22,7 +22,7 @@ matrix:
     - env: T=2.9/linux/opensuse15/1
     - env: T=2.9/linux/ubuntu1604/1
     - env: T=2.9/linux/ubuntu1804/1
-    - env: T=2.10/aix/7.2/1
+#    - env: T=2.10/aix/7.2/1
     - env: T=2.10/osx/10.11/1
     - env: T=2.10/rhel/7.6/1
     - env: T=2.10/rhel/8.2/1
@@ -37,7 +37,7 @@ matrix:
     - env: T=2.10/linux/opensuse15/1
     - env: T=2.10/linux/ubuntu1604/1
     - env: T=2.10/linux/ubuntu1804/1
-    - env: T=devel/aix/7.2/1
+#    - env: T=devel/aix/7.2/1
     - env: T=devel/osx/10.11/1
     - env: T=devel/rhel/7.6/1
     - env: T=devel/rhel/8.1/1


### PR DESCRIPTION

Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
disable AIX tests in shippable for now because of intermittent failures from IBM Cloud
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.posix