### PR TITLE
Fix synchronize to work with renamed docker and buildah connection plugins.

### DIFF
--- a/changelogs/fragments/74_synchronize_docker.yml
+++ b/changelogs/fragments/74_synchronize_docker.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- Fix synchronize to work with renamed docker and buildah connection plugins.


### PR DESCRIPTION
##### SUMMARY

Adds the new collection-namespaced names for `docker` and `buildah` connection plugins to the conditionals in the `synchronize` action plugin.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`synchronize` action plugin

##### ADDITIONAL INFORMATION

With certain connection plugins moved into collections, the `docker` and `buildah` connections are redirected to  `ansible.community.docker` and `containers.podman.buildah`, respectively. Since the `synchronize` action plugin is explicitly checking for `docker` and `buildah`, it fails to work as-is with the updated connection names. e.g:

```
fatal: [docker_host]: FAILED! => {"changed": false, "msg": "synchronize uses rsync to function. rsync needs to connect to the remote host via ssh, docker client or a direct filesystem copy. This remote host is being accessed via community.general.docker instead so it cannot work."}
```

With this PR, it works again (I've only tested with docker).