### PR TITLE
firewalld: Add a Link for rich rules

### DIFF
--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -27,6 +27,7 @@ options:
   rich_rule:
     description:
       - Rich rule to add/remove to/from firewalld.
+      - See L(Syntax for firewalld rich language rules,https://firewalld.org/documentation/man-pages/firewalld.richlanguage.html).
     type: str
   source:
     description:


### PR DESCRIPTION
##### SUMMARY

Add a link for Firewalld Rich Rules for further documentation.

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
plugins/modules/firewalld.py
