### PR TITLE
Fix for private_key overriding in synchronize module

### DIFF
--- a/changelogs/fragments/82-private-key-override-fix.yml
+++ b/changelogs/fragments/82-private-key-override-fix.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - synchronize - Fix for private_key overriding in synchronize module

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -333,10 +333,8 @@ class ActionModule(ActionBase):
                     user = task_vars.get('ansible_ssh_user') or self._play_context.remote_user
 
             # Private key handling
-            private_key = self._play_context.private_key_file
-
-            if private_key is not None:
-                _tmp_args['private_key'] = private_key
+            # Use the private_key parameter if passed else use context private_key_file
+            _tmp_args['private_key'] = _tmp_args.get('private_key', self._play_context.private_key_file)
 
             # use the mode to define src and dest's url
             if _tmp_args.get('mode', 'push') == 'pull':

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/meta.yaml
@@ -1,0 +1,25 @@
+fixtures:
+    taskvars_in: taskvars_in.json
+    taskvars_out: taskvars_out.json
+connection:
+    transport: 'ssh'
+hostvars:
+    '127.0.0.1': {}
+    '::1': {}
+    'localhost': {}
+_play_context:
+   private_key_file: ~/test.pem
+task_args:
+   private_key: ~/.ssh/id_rsa
+   dest: /tmp/deleteme
+   src: /tmp/deleteme
+
+asserts:
+    - "hasattr(SAM._connection, 'ismock')"
+    - "SAM._connection.transport == 'local'"
+    - "self._play_context.shell == 'sh'"
+    - "self.execute_called"
+    - "self.final_module_args['_local_rsync_path'] == 'rsync'"
+    - "self.final_module_args['src'] == '/tmp/deleteme'"
+    - "self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'"
+    - "self.final_module_args['private_key'] == '~/.ssh/id_rsa'"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/taskvars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/taskvars_in.json
@@ -1,0 +1,151 @@
+{
+  "ansible_pipelining": false, 
+  "ansible_docker_extra_args": "", 
+  "ansible_scp_extra_args": "", 
+  "ansible_user": "root", 
+  "ansible_play_hosts": [
+    "el6host"
+  ], 
+  "ansible_connection": "smart", 
+  "ansible_ssh_common_args": "", 
+  "environment": [], 
+  "inventory_hostname": "el6host", 
+  "vars": {
+    "ansible_check_mode": false, 
+    "inventory_hostname": "el6host", 
+    "inventory_file": "inventory", 
+    "inventory_hostname_short": "el6host", 
+    "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "role_names": [], 
+    "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "environment": [], 
+    "play_hosts": [
+      "el6host"
+    ], 
+    "ansible_play_hosts": [
+      "el6host"
+    ], 
+    "hostvars": {
+      "el6host": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host"
+          ], 
+          "all": [
+            "el6host"
+          ]
+        }, 
+        "inventory_hostname": "el6host", 
+        "inventory_hostname_short": "el6host", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "root", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }
+    }, 
+    "groups": {
+      "ungrouped": [
+        "el6host"
+      ], 
+      "all": [
+        "el6host"
+      ]
+    }, 
+    "group_names": [
+      "ungrouped"
+    ], 
+    "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
+    "ansible_version": {
+      "major": 2, 
+      "full": "2.2.0", 
+      "string": "2.2.0", 
+      "minor": 2, 
+      "revision": 0
+    }, 
+    "ansible_ssh_user": "root"
+  }, 
+  "ansible_accelerate_port": 5099, 
+  "roledir": null, 
+  "ansible_ssh_extra_args": "", 
+  "ansible_ssh_host": "el6host", 
+  "ansible_current_hosts": [
+    "el6host"
+  ], 
+  "hostvars": {
+    "el6host": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host"
+        ], 
+        "all": [
+          "el6host"
+        ]
+      }, 
+      "inventory_hostname": "el6host", 
+      "inventory_hostname_short": "el6host", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "root", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }
+  }, 
+  "group_names": [
+    "ungrouped"
+  ], 
+  "ansible_version": {
+    "major": 2, 
+    "full": "2.2.0", 
+    "string": "2.2.0", 
+    "minor": 2, 
+    "revision": 0
+  }, 
+  "ansible_ssh_pipelining": false, 
+  "inventory_file": "inventory", 
+  "ansible_module_compression": "ZIP_DEFLATED", 
+  "ansible_failed_hosts": [], 
+  "ansible_check_mode": false, 
+  "groups": {
+    "ungrouped": [
+      "el6host"
+    ], 
+    "all": [
+      "el6host"
+    ]
+  }, 
+  "ansible_host": "el6host", 
+  "ansible_shell_executable": "/bin/sh", 
+  "inventory_hostname_short": "el6host", 
+  "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
+  "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "ansible_ssh_user": "root", 
+  "role_names": [], 
+  "play_hosts": [
+    "el6host"
+  ], 
+  "ansible_sftp_extra_args": ""
+}

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/taskvars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/taskvars_out.json
@@ -1,0 +1,156 @@
+{
+  "ansible_pipelining": false, 
+  "ansible_docker_extra_args": "", 
+  "ansible_scp_extra_args": "", 
+  "ansible_user": "root", 
+  "ansible_play_hosts": [
+    "el6host"
+  ], 
+  "ansible_connection": "smart", 
+  "ansible_ssh_common_args": "", 
+  "environment": [], 
+  "inventory_hostname": "el6host", 
+  "vars": {
+    "ansible_check_mode": false, 
+    "inventory_hostname": "el6host", 
+    "inventory_file": "inventory", 
+    "inventory_hostname_short": "el6host", 
+    "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "role_names": [], 
+    "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "environment": [], 
+    "play_hosts": [
+      "el6host"
+    ], 
+    "ansible_play_hosts": [
+      "el6host"
+    ], 
+    "hostvars": {
+      "el6host": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "::1"
+          ], 
+          "all": [
+            "el6host", 
+            "::1"
+          ]
+        }, 
+        "inventory_hostname": "el6host", 
+        "inventory_hostname_short": "el6host", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "root", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }
+    }, 
+    "groups": {
+      "ungrouped": [
+        "el6host"
+      ], 
+      "all": [
+        "el6host"
+      ]
+    }, 
+    "group_names": [
+      "ungrouped"
+    ], 
+    "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
+    "ansible_version": {
+      "major": 2, 
+      "full": "2.2.0", 
+      "string": "2.2.0", 
+      "minor": 2, 
+      "revision": 0
+    }, 
+    "ansible_ssh_user": "root"
+  }, 
+  "ansible_accelerate_port": 5099, 
+  "roledir": null, 
+  "ansible_ssh_extra_args": "", 
+  "ansible_ssh_host": "el6host", 
+  "ansible_current_hosts": [
+    "el6host"
+  ], 
+  "hostvars": {
+    "el6host": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "::1"
+        ], 
+        "all": [
+          "el6host", 
+          "::1"
+        ]
+      }, 
+      "inventory_hostname": "el6host", 
+      "inventory_hostname_short": "el6host", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "root", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }
+  }, 
+  "group_names": [
+    "ungrouped"
+  ], 
+  "ansible_version": {
+    "major": 2, 
+    "full": "2.2.0", 
+    "string": "2.2.0", 
+    "minor": 2, 
+    "revision": 0
+  }, 
+  "ansible_ssh_pipelining": false, 
+  "inventory_file": "inventory", 
+  "ansible_module_compression": "ZIP_DEFLATED", 
+  "ansible_failed_hosts": [], 
+  "ansible_check_mode": false, 
+  "groups": {
+    "ungrouped": [
+      "el6host"
+    ], 
+    "all": [
+      "el6host"
+    ]
+  }, 
+  "ansible_host": "el6host", 
+  "ansible_shell_executable": "/bin/sh", 
+  "inventory_hostname_short": "el6host", 
+  "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
+  "ansible_python_interpreter": "/usr/bin/python", 
+  "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "ansible_ssh_user": "root", 
+  "role_names": [], 
+  "play_hosts": [
+    "el6host"
+  ], 
+  "ansible_sftp_extra_args": ""
+}

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_play_context_private_key/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_play_context_private_key/meta.yaml
@@ -1,0 +1,28 @@
+fixtures:
+    taskvars_in: task_vars_in.json
+    taskvars_out: task_vars_out.json
+task_args:
+    src: /tmp/deleteme
+    dest: /tmp/deleteme
+_task:
+    delegate_to: u1404    
+_play_context:
+    shell: None
+    remote_addr: u1404
+    remote_user: root
+    private_key_file: ~/test.pem
+connection:
+    transport: 'ssh'
+hostvars:
+    '127.0.0.1': {}
+    '::1': {}
+    'localhost': {}
+asserts:
+    - "hasattr(SAM._connection, 'ismock')"
+    - "SAM._connection.transport == 'ssh'"
+    - "self._play_context.shell == None"
+    - "self.execute_called"
+    - "self.final_module_args['_local_rsync_path'] == 'rsync'"
+    - "self.final_module_args['src'] == '/tmp/deleteme'"
+    - "self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'"
+    - "self.final_module_args['private_key'] == '~/test.pem'"

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_play_context_private_key/task_vars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_play_context_private_key/task_vars_in.json
@@ -1,0 +1,379 @@
+{
+  "ansible_pipelining": false, 
+  "ansible_docker_extra_args": "", 
+  "ansible_scp_extra_args": "", 
+  "ansible_user": "root", 
+  "ansible_play_hosts": [
+    "el6host"
+  ], 
+  "ansible_connection": "smart", 
+  "ansible_ssh_common_args": "", 
+  "environment": [], 
+  "inventory_hostname": "el6host", 
+  "vars": {
+    "ansible_check_mode": false, 
+    "inventory_hostname": "el6host", 
+    "inventory_file": "inventory", 
+    "ansible_delegated_vars": {
+      "u1404": {
+        "inventory_hostname": "u1404", 
+        "inventory_file": "inventory", 
+        "vars": {
+          "inventory_file": "inventory", 
+          "role_names": [], 
+          "ansible_play_hosts": [
+            "el6host"
+          ], 
+          "groups": {
+            "ungrouped": [
+              "el6host", 
+              "u1404"
+            ], 
+            "all": [
+              "el6host", 
+              "u1404"
+            ]
+          }, 
+          "ansible_check_mode": false, 
+          "inventory_hostname": "u1404", 
+          "inventory_hostname_short": "u1404", 
+          "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+          "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+          "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+          "environment": [], 
+          "ansible_ssh_user": "root", 
+          "group_names": [
+            "ungrouped"
+          ], 
+          "play_hosts": [
+            "el6host"
+          ], 
+          "ansible_version": {
+            "major": 2, 
+            "full": "2.2.0", 
+            "string": "2.2.0", 
+            "minor": 2, 
+            "revision": 0
+          }
+        }, 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "ansible_host": "u1404", 
+        "environment": [], 
+        "ansible_play_hosts": [
+          "el6host"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "ansible_check_mode": false, 
+        "play_hosts": [
+          "el6host"
+        ], 
+        "role_names": [], 
+        "ansible_port": null, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }, 
+        "ansible_ssh_user": "root"
+      }
+    }, 
+    "inventory_hostname_short": "el6host", 
+    "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "role_names": [], 
+    "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "environment": [], 
+    "play_hosts": [
+      "el6host"
+    ], 
+    "ansible_play_hosts": [
+      "el6host"
+    ], 
+    "hostvars": {
+      "el6host": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "inventory_hostname": "el6host", 
+        "inventory_hostname_short": "el6host", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "root", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }, 
+      "u1404": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "inventory_hostname": "u1404", 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "root", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }
+    }, 
+    "groups": {
+      "ungrouped": [
+        "el6host", 
+        "u1404"
+      ], 
+      "all": [
+        "el6host", 
+        "u1404"
+      ]
+    }, 
+    "group_names": [
+      "ungrouped"
+    ], 
+    "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+    "ansible_version": {
+      "major": 2, 
+      "full": "2.2.0", 
+      "string": "2.2.0", 
+      "minor": 2, 
+      "revision": 0
+    }, 
+    "ansible_ssh_user": "root"
+  }, 
+  "ansible_accelerate_port": 5099, 
+  "roledir": null, 
+  "ansible_ssh_extra_args": "", 
+  "ansible_ssh_host": "u1404", 
+  "ansible_current_hosts": [
+    "el6host"
+  ], 
+  "hostvars": {
+    "el6host": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404"
+        ]
+      }, 
+      "inventory_hostname": "el6host", 
+      "inventory_hostname_short": "el6host", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "root", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }, 
+    "u1404": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404"
+        ]
+      }, 
+      "inventory_hostname": "u1404", 
+      "inventory_hostname_short": "u1404", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "root", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }
+  }, 
+  "group_names": [
+    "ungrouped"
+  ], 
+  "ansible_version": {
+    "major": 2, 
+    "full": "2.2.0", 
+    "string": "2.2.0", 
+    "minor": 2, 
+    "revision": 0
+  }, 
+  "ansible_ssh_pipelining": false, 
+  "inventory_file": "inventory", 
+  "ansible_delegated_vars": {
+    "u1404": {
+      "inventory_hostname": "u1404", 
+      "inventory_file": "inventory", 
+      "vars": {
+        "ansible_check_mode": false, 
+        "inventory_hostname": "u1404", 
+        "inventory_file": "inventory", 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "environment": [], 
+        "ansible_ssh_user": "root", 
+        "ansible_play_hosts": [
+          "el6host"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "play_hosts": [
+          "el6host"
+        ], 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }, 
+        "role_names": []
+      }, 
+      "inventory_hostname_short": "u1404", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "ansible_host": "u1404", 
+      "environment": [], 
+      "ansible_play_hosts": [
+        "el6host"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404"
+        ]
+      }, 
+      "ansible_check_mode": false, 
+      "play_hosts": [
+        "el6host"
+      ], 
+      "role_names": [], 
+      "ansible_port": null, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }, 
+      "ansible_ssh_user": "root"
+    }
+  }, 
+  "ansible_module_compression": "ZIP_DEFLATED", 
+  "ansible_failed_hosts": [], 
+  "ansible_check_mode": false, 
+  "groups": {
+    "ungrouped": [
+      "el6host", 
+      "u1404"
+    ], 
+    "all": [
+      "el6host", 
+      "u1404"
+    ]
+  }, 
+  "ansible_host": "u1404", 
+  "ansible_shell_executable": "/bin/sh", 
+  "inventory_hostname_short": "el6host", 
+  "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+  "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "ansible_ssh_user": "root", 
+  "role_names": [], 
+  "play_hosts": [
+    "el6host"
+  ], 
+  "ansible_sftp_extra_args": ""
+}

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_play_context_private_key/task_vars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_play_context_private_key/task_vars_out.json
@@ -1,0 +1,387 @@
+{
+  "ansible_pipelining": false, 
+  "ansible_docker_extra_args": "", 
+  "ansible_scp_extra_args": "", 
+  "ansible_user": "root", 
+  "ansible_play_hosts": [
+    "el6host"
+  ], 
+  "ansible_connection": "smart", 
+  "ansible_ssh_common_args": "", 
+  "environment": [], 
+  "inventory_hostname": "el6host", 
+  "vars": {
+    "ansible_check_mode": false, 
+    "inventory_hostname": "el6host", 
+    "inventory_file": "inventory", 
+    "ansible_delegated_vars": {
+      "u1404": {
+        "inventory_hostname": "u1404", 
+        "inventory_file": "inventory", 
+        "vars": {
+          "inventory_file": "inventory", 
+          "role_names": [], 
+          "ansible_play_hosts": [
+            "el6host"
+          ], 
+          "groups": {
+            "ungrouped": [
+              "el6host", 
+              "u1404"
+            ], 
+            "all": [
+              "el6host", 
+              "u1404"
+            ]
+          }, 
+          "ansible_check_mode": false, 
+          "inventory_hostname": "u1404", 
+          "inventory_hostname_short": "u1404", 
+          "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+          "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+          "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+          "environment": [], 
+          "ansible_ssh_user": "root", 
+          "group_names": [
+            "ungrouped"
+          ], 
+          "play_hosts": [
+            "el6host"
+          ], 
+          "ansible_version": {
+            "major": 2, 
+            "full": "2.2.0", 
+            "string": "2.2.0", 
+            "minor": 2, 
+            "revision": 0
+          }
+        }, 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "ansible_host": "u1404", 
+        "environment": [], 
+        "ansible_play_hosts": [
+          "el6host"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "ansible_check_mode": false, 
+        "play_hosts": [
+          "el6host"
+        ], 
+        "role_names": [], 
+        "ansible_port": null, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }, 
+        "ansible_ssh_user": "root"
+      }
+    }, 
+    "inventory_hostname_short": "el6host", 
+    "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "role_names": [], 
+    "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "environment": [], 
+    "play_hosts": [
+      "el6host"
+    ], 
+    "ansible_play_hosts": [
+      "el6host"
+    ], 
+    "hostvars": {
+      "el6host": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404", 
+            "::1"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404", 
+            "::1"
+          ]
+        }, 
+        "inventory_hostname": "el6host", 
+        "inventory_hostname_short": "el6host", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "root", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }, 
+      "u1404": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404", 
+            "::1"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404", 
+            "::1"
+          ]
+        }, 
+        "inventory_hostname": "u1404", 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "root", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }
+    }, 
+    "groups": {
+      "ungrouped": [
+        "el6host", 
+        "u1404"
+      ], 
+      "all": [
+        "el6host", 
+        "u1404"
+      ]
+    }, 
+    "group_names": [
+      "ungrouped"
+    ], 
+    "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+    "ansible_version": {
+      "major": 2, 
+      "full": "2.2.0", 
+      "string": "2.2.0", 
+      "minor": 2, 
+      "revision": 0
+    }, 
+    "ansible_ssh_user": "root"
+  }, 
+  "ansible_accelerate_port": 5099, 
+  "roledir": null, 
+  "ansible_ssh_extra_args": "", 
+  "ansible_ssh_host": "u1404", 
+  "ansible_current_hosts": [
+    "el6host"
+  ], 
+  "hostvars": {
+    "el6host": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404", 
+          "::1"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404", 
+          "::1"
+        ]
+      }, 
+      "inventory_hostname": "el6host", 
+      "inventory_hostname_short": "el6host", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "root", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }, 
+    "u1404": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404", 
+          "::1"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404", 
+          "::1"
+        ]
+      }, 
+      "inventory_hostname": "u1404", 
+      "inventory_hostname_short": "u1404", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "root", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }
+  }, 
+  "group_names": [
+    "ungrouped"
+  ], 
+  "ansible_version": {
+    "major": 2, 
+    "full": "2.2.0", 
+    "string": "2.2.0", 
+    "minor": 2, 
+    "revision": 0
+  }, 
+  "ansible_ssh_pipelining": false, 
+  "inventory_file": "inventory", 
+  "ansible_delegated_vars": {
+    "u1404": {
+      "inventory_hostname": "u1404", 
+      "inventory_file": "inventory", 
+      "vars": {
+        "ansible_check_mode": false, 
+        "inventory_hostname": "u1404", 
+        "inventory_file": "inventory", 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "environment": [], 
+        "ansible_ssh_user": "root", 
+        "ansible_play_hosts": [
+          "el6host"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "play_hosts": [
+          "el6host"
+        ], 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }, 
+        "role_names": []
+      }, 
+      "inventory_hostname_short": "u1404", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "ansible_host": "u1404", 
+      "environment": [], 
+      "ansible_play_hosts": [
+        "el6host"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404"
+        ]
+      }, 
+      "ansible_check_mode": false, 
+      "play_hosts": [
+        "el6host"
+      ], 
+      "role_names": [], 
+      "ansible_port": null, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }, 
+      "ansible_ssh_user": "root"
+    }
+  }, 
+  "ansible_module_compression": "ZIP_DEFLATED", 
+  "ansible_failed_hosts": [], 
+  "ansible_check_mode": false, 
+  "groups": {
+    "ungrouped": [
+      "el6host", 
+      "u1404"
+    ], 
+    "all": [
+      "el6host", 
+      "u1404"
+    ]
+  }, 
+  "ansible_host": "u1404", 
+  "ansible_shell_executable": "/bin/sh", 
+  "inventory_hostname_short": "el6host", 
+  "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+  "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "ansible_ssh_user": "root", 
+  "role_names": [], 
+  "play_hosts": [
+    "el6host"
+  ], 
+  "ansible_sftp_extra_args": ""
+}

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_with_private_key/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_with_private_key/meta.yaml
@@ -1,0 +1,29 @@
+fixtures:
+    taskvars_in: task_vars_in.json
+    taskvars_out: task_vars_out.json
+task_args:
+    src: /tmp/deleteme
+    dest: /tmp/deleteme
+    private_key: ~/.ssh/id_rsa
+_task:
+    delegate_to: u1404    
+_play_context:
+    shell: None
+    remote_addr: u1404
+    remote_user: root
+    private_key_file: ~/test.pem
+connection:
+    transport: 'ssh'
+hostvars:
+    '127.0.0.1': {}
+    '::1': {}
+    'localhost': {}
+asserts:
+    - "hasattr(SAM._connection, 'ismock')"
+    - "SAM._connection.transport == 'ssh'"
+    - "self._play_context.shell == None"
+    - "self.execute_called"
+    - "self.final_module_args['_local_rsync_path'] == 'rsync'"
+    - "self.final_module_args['src'] == '/tmp/deleteme'"
+    - "self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'"
+    - "self.final_module_args['private_key'] == '~/.ssh/id_rsa'"

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_with_private_key/task_vars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_with_private_key/task_vars_in.json
@@ -1,0 +1,379 @@
+{
+  "ansible_pipelining": false, 
+  "ansible_docker_extra_args": "", 
+  "ansible_scp_extra_args": "", 
+  "ansible_user": "root", 
+  "ansible_play_hosts": [
+    "el6host"
+  ], 
+  "ansible_connection": "smart", 
+  "ansible_ssh_common_args": "", 
+  "environment": [], 
+  "inventory_hostname": "el6host", 
+  "vars": {
+    "ansible_check_mode": false, 
+    "inventory_hostname": "el6host", 
+    "inventory_file": "inventory", 
+    "ansible_delegated_vars": {
+      "u1404": {
+        "inventory_hostname": "u1404", 
+        "inventory_file": "inventory", 
+        "vars": {
+          "inventory_file": "inventory", 
+          "role_names": [], 
+          "ansible_play_hosts": [
+            "el6host"
+          ], 
+          "groups": {
+            "ungrouped": [
+              "el6host", 
+              "u1404"
+            ], 
+            "all": [
+              "el6host", 
+              "u1404"
+            ]
+          }, 
+          "ansible_check_mode": false, 
+          "inventory_hostname": "u1404", 
+          "inventory_hostname_short": "u1404", 
+          "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+          "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+          "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+          "environment": [], 
+          "ansible_ssh_user": "root", 
+          "group_names": [
+            "ungrouped"
+          ], 
+          "play_hosts": [
+            "el6host"
+          ], 
+          "ansible_version": {
+            "major": 2, 
+            "full": "2.2.0", 
+            "string": "2.2.0", 
+            "minor": 2, 
+            "revision": 0
+          }
+        }, 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "ansible_host": "u1404", 
+        "environment": [], 
+        "ansible_play_hosts": [
+          "el6host"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "ansible_check_mode": false, 
+        "play_hosts": [
+          "el6host"
+        ], 
+        "role_names": [], 
+        "ansible_port": null, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }, 
+        "ansible_ssh_user": "root"
+      }
+    }, 
+    "inventory_hostname_short": "el6host", 
+    "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "role_names": [], 
+    "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "environment": [], 
+    "play_hosts": [
+      "el6host"
+    ], 
+    "ansible_play_hosts": [
+      "el6host"
+    ], 
+    "hostvars": {
+      "el6host": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "inventory_hostname": "el6host", 
+        "inventory_hostname_short": "el6host", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "root", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }, 
+      "u1404": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "inventory_hostname": "u1404", 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "root", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }
+    }, 
+    "groups": {
+      "ungrouped": [
+        "el6host", 
+        "u1404"
+      ], 
+      "all": [
+        "el6host", 
+        "u1404"
+      ]
+    }, 
+    "group_names": [
+      "ungrouped"
+    ], 
+    "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+    "ansible_version": {
+      "major": 2, 
+      "full": "2.2.0", 
+      "string": "2.2.0", 
+      "minor": 2, 
+      "revision": 0
+    }, 
+    "ansible_ssh_user": "root"
+  }, 
+  "ansible_accelerate_port": 5099, 
+  "roledir": null, 
+  "ansible_ssh_extra_args": "", 
+  "ansible_ssh_host": "u1404", 
+  "ansible_current_hosts": [
+    "el6host"
+  ], 
+  "hostvars": {
+    "el6host": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404"
+        ]
+      }, 
+      "inventory_hostname": "el6host", 
+      "inventory_hostname_short": "el6host", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "root", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }, 
+    "u1404": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404"
+        ]
+      }, 
+      "inventory_hostname": "u1404", 
+      "inventory_hostname_short": "u1404", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "root", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }
+  }, 
+  "group_names": [
+    "ungrouped"
+  ], 
+  "ansible_version": {
+    "major": 2, 
+    "full": "2.2.0", 
+    "string": "2.2.0", 
+    "minor": 2, 
+    "revision": 0
+  }, 
+  "ansible_ssh_pipelining": false, 
+  "inventory_file": "inventory", 
+  "ansible_delegated_vars": {
+    "u1404": {
+      "inventory_hostname": "u1404", 
+      "inventory_file": "inventory", 
+      "vars": {
+        "ansible_check_mode": false, 
+        "inventory_hostname": "u1404", 
+        "inventory_file": "inventory", 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "environment": [], 
+        "ansible_ssh_user": "root", 
+        "ansible_play_hosts": [
+          "el6host"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "play_hosts": [
+          "el6host"
+        ], 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }, 
+        "role_names": []
+      }, 
+      "inventory_hostname_short": "u1404", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "ansible_host": "u1404", 
+      "environment": [], 
+      "ansible_play_hosts": [
+        "el6host"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404"
+        ]
+      }, 
+      "ansible_check_mode": false, 
+      "play_hosts": [
+        "el6host"
+      ], 
+      "role_names": [], 
+      "ansible_port": null, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }, 
+      "ansible_ssh_user": "root"
+    }
+  }, 
+  "ansible_module_compression": "ZIP_DEFLATED", 
+  "ansible_failed_hosts": [], 
+  "ansible_check_mode": false, 
+  "groups": {
+    "ungrouped": [
+      "el6host", 
+      "u1404"
+    ], 
+    "all": [
+      "el6host", 
+      "u1404"
+    ]
+  }, 
+  "ansible_host": "u1404", 
+  "ansible_shell_executable": "/bin/sh", 
+  "inventory_hostname_short": "el6host", 
+  "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+  "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "ansible_ssh_user": "root", 
+  "role_names": [], 
+  "play_hosts": [
+    "el6host"
+  ], 
+  "ansible_sftp_extra_args": ""
+}

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_with_private_key/task_vars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_with_private_key/task_vars_out.json
@@ -1,0 +1,387 @@
+{
+  "ansible_pipelining": false, 
+  "ansible_docker_extra_args": "", 
+  "ansible_scp_extra_args": "", 
+  "ansible_user": "root", 
+  "ansible_play_hosts": [
+    "el6host"
+  ], 
+  "ansible_connection": "smart", 
+  "ansible_ssh_common_args": "", 
+  "environment": [], 
+  "inventory_hostname": "el6host", 
+  "vars": {
+    "ansible_check_mode": false, 
+    "inventory_hostname": "el6host", 
+    "inventory_file": "inventory", 
+    "ansible_delegated_vars": {
+      "u1404": {
+        "inventory_hostname": "u1404", 
+        "inventory_file": "inventory", 
+        "vars": {
+          "inventory_file": "inventory", 
+          "role_names": [], 
+          "ansible_play_hosts": [
+            "el6host"
+          ], 
+          "groups": {
+            "ungrouped": [
+              "el6host", 
+              "u1404"
+            ], 
+            "all": [
+              "el6host", 
+              "u1404"
+            ]
+          }, 
+          "ansible_check_mode": false, 
+          "inventory_hostname": "u1404", 
+          "inventory_hostname_short": "u1404", 
+          "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+          "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+          "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+          "environment": [], 
+          "ansible_ssh_user": "root", 
+          "group_names": [
+            "ungrouped"
+          ], 
+          "play_hosts": [
+            "el6host"
+          ], 
+          "ansible_version": {
+            "major": 2, 
+            "full": "2.2.0", 
+            "string": "2.2.0", 
+            "minor": 2, 
+            "revision": 0
+          }
+        }, 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "ansible_host": "u1404", 
+        "environment": [], 
+        "ansible_play_hosts": [
+          "el6host"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "ansible_check_mode": false, 
+        "play_hosts": [
+          "el6host"
+        ], 
+        "role_names": [], 
+        "ansible_port": null, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }, 
+        "ansible_ssh_user": "root"
+      }
+    }, 
+    "inventory_hostname_short": "el6host", 
+    "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "role_names": [], 
+    "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+    "environment": [], 
+    "play_hosts": [
+      "el6host"
+    ], 
+    "ansible_play_hosts": [
+      "el6host"
+    ], 
+    "hostvars": {
+      "el6host": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404", 
+            "::1"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404", 
+            "::1"
+          ]
+        }, 
+        "inventory_hostname": "el6host", 
+        "inventory_hostname_short": "el6host", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "root", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }, 
+      "u1404": {
+        "inventory_file": "inventory", 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404", 
+            "::1"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404", 
+            "::1"
+          ]
+        }, 
+        "inventory_hostname": "u1404", 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "ansible_ssh_user": "root", 
+        "ansible_check_mode": false, 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }
+      }
+    }, 
+    "groups": {
+      "ungrouped": [
+        "el6host", 
+        "u1404"
+      ], 
+      "all": [
+        "el6host", 
+        "u1404"
+      ]
+    }, 
+    "group_names": [
+      "ungrouped"
+    ], 
+    "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+    "ansible_version": {
+      "major": 2, 
+      "full": "2.2.0", 
+      "string": "2.2.0", 
+      "minor": 2, 
+      "revision": 0
+    }, 
+    "ansible_ssh_user": "root"
+  }, 
+  "ansible_accelerate_port": 5099, 
+  "roledir": null, 
+  "ansible_ssh_extra_args": "", 
+  "ansible_ssh_host": "u1404", 
+  "ansible_current_hosts": [
+    "el6host"
+  ], 
+  "hostvars": {
+    "el6host": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404", 
+          "::1"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404", 
+          "::1"
+        ]
+      }, 
+      "inventory_hostname": "el6host", 
+      "inventory_hostname_short": "el6host", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "root", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }, 
+    "u1404": {
+      "inventory_file": "inventory", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404", 
+          "::1"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404", 
+          "::1"
+        ]
+      }, 
+      "inventory_hostname": "u1404", 
+      "inventory_hostname_short": "u1404", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "ansible_ssh_user": "root", 
+      "ansible_check_mode": false, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }
+    }
+  }, 
+  "group_names": [
+    "ungrouped"
+  ], 
+  "ansible_version": {
+    "major": 2, 
+    "full": "2.2.0", 
+    "string": "2.2.0", 
+    "minor": 2, 
+    "revision": 0
+  }, 
+  "ansible_ssh_pipelining": false, 
+  "inventory_file": "inventory", 
+  "ansible_delegated_vars": {
+    "u1404": {
+      "inventory_hostname": "u1404", 
+      "inventory_file": "inventory", 
+      "vars": {
+        "ansible_check_mode": false, 
+        "inventory_hostname": "u1404", 
+        "inventory_file": "inventory", 
+        "inventory_hostname_short": "u1404", 
+        "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+        "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+        "environment": [], 
+        "ansible_ssh_user": "root", 
+        "ansible_play_hosts": [
+          "el6host"
+        ], 
+        "groups": {
+          "ungrouped": [
+            "el6host", 
+            "u1404"
+          ], 
+          "all": [
+            "el6host", 
+            "u1404"
+          ]
+        }, 
+        "group_names": [
+          "ungrouped"
+        ], 
+        "play_hosts": [
+          "el6host"
+        ], 
+        "ansible_version": {
+          "major": 2, 
+          "full": "2.2.0", 
+          "string": "2.2.0", 
+          "minor": 2, 
+          "revision": 0
+        }, 
+        "role_names": []
+      }, 
+      "inventory_hostname_short": "u1404", 
+      "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "group_names": [
+        "ungrouped"
+      ], 
+      "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+      "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+      "ansible_host": "u1404", 
+      "environment": [], 
+      "ansible_play_hosts": [
+        "el6host"
+      ], 
+      "groups": {
+        "ungrouped": [
+          "el6host", 
+          "u1404"
+        ], 
+        "all": [
+          "el6host", 
+          "u1404"
+        ]
+      }, 
+      "ansible_check_mode": false, 
+      "play_hosts": [
+        "el6host"
+      ], 
+      "role_names": [], 
+      "ansible_port": null, 
+      "ansible_version": {
+        "major": 2, 
+        "full": "2.2.0", 
+        "string": "2.2.0", 
+        "minor": 2, 
+        "revision": 0
+      }, 
+      "ansible_ssh_user": "root"
+    }
+  }, 
+  "ansible_module_compression": "ZIP_DEFLATED", 
+  "ansible_failed_hosts": [], 
+  "ansible_check_mode": false, 
+  "groups": {
+    "ungrouped": [
+      "el6host", 
+      "u1404"
+    ], 
+    "all": [
+      "el6host", 
+      "u1404"
+    ]
+  }, 
+  "ansible_host": "u1404", 
+  "ansible_shell_executable": "/bin/sh", 
+  "inventory_hostname_short": "el6host", 
+  "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
+  "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
+  "ansible_ssh_user": "root", 
+  "role_names": [], 
+  "play_hosts": [
+    "el6host"
+  ], 
+  "ansible_sftp_extra_args": ""
+}

--- a/tests/unit/plugins/action/test_synchronize.py
+++ b/tests/unit/plugins/action/test_synchronize.py
@@ -251,6 +251,23 @@ class TestSynchronizeAction(unittest.TestCase):
         x = SynchronizeTester()
         x.runtest(fixturepath=os.path.join(self.fixturedir, 'delegate_remote_su'))
 
+    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
+    def test_basic_with_private_key(self):
+        x = SynchronizeTester()
+        x.runtest(fixturepath=os.path.join(self.fixturedir, 'basic_with_private_key'))
+
+    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
+    def test_delegate_remote_with_private_key(self):
+        # delegate to other remote host and use the module param private_key
+        x = SynchronizeTester()
+        x.runtest(fixturepath=os.path.join(self.fixturedir, 'delegate_remote_with_private_key'))
+
+    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
+    def test_delegate_remote_play_context_private_key(self):
+        # delegate to other remote host and use the play context private_key
+        x = SynchronizeTester()
+        x.runtest(fixturepath=os.path.join(self.fixturedir, 'delegate_remote_play_context_private_key'))
+
     @patch.object(ActionModule, '_low_level_execute_command', side_effect=BreakPoint)
     @patch.object(ActionModule, '_remote_expand_user', side_effect=ActionModule._remote_expand_user, autospec=True)
     def test_remote_user_not_in_local_tmpdir(self, spy_remote_expand_user, ll_ec):


### PR DESCRIPTION
##### SUMMARY
The private_key parameter of synchronize module task gets overridden by the playbook --private-key variable path.
This PR is used to fix this. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
synchronize

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
##### Playbook content
```
cat play.yml
- hosts: agents
  remote_user: vbm
  tasks:
    - name: Fetching the /etc/hosts from manager to agent nodes
      synchronize:
        src:  "/etc/hosts"
        dest: "/home/vbm/"
        private_key: "/home/vbm/test.pem"
      delegate_to: "{{item}}"
      with_items: "{{groups['manager']}}"
```
##### Playbook invocation command
```
ansible-playbook --private-key=/home/vbm/access.pem -i inventory play.yml -vvv
```
##### Error message:
```	  
failed: [10.75.180.184 -> 10.75.180.139] (item=10.75.180.139) => {
    "ansible_loop_var": "item",
    "changed": false,
    "cmd": "/usr/bin/rsync --delay-updates -F --compress --archive --rsh=/usr/bin/ssh -S none -i /home/vbm/access.pem -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null --out-format=<<CHANGED>>%i %n%L /etc/hosts vbm@10.75.180.184:/home/vbm/",
    "invocation": {
        "module_args": {
            "_local_rsync_password": null,
            ...
            "perms": null,
            "private_key": "/home/vbm/access.pem",
            ...
            "src": "/etc/hosts",
            "ssh_args": null,
            ...
        }
    },
    "item": "10.75.180.139",
    "msg": "Warning: Identity file /home/vbm/access.pem not accessible: No such file or directory.\nWarning: Permanently added '10.75.180.184' (ECDSA) to the list of known hosts.\r\n\\S\nKernel \\r on an \\m\nPermission denied (publickey,gssapi-keyex,gssapi-with-mic).\r\nrsync: connection unexpectedly closed (0 bytes received so far) [sender]\nrsync error: error in rsync protocol data stream (code 12) at io.c(226) [sender=3.1.2]\n",
    "rc": 12
}
```

#### Expectation:
##### The private_key parameter in the module_args should have been `/home/vbm/test.pem` instead of `/home/vbm/access.pem`