### PR TITLE
Add execution environment metadata

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,3 @@
+at [platform:rpm]
+python3-libselinux [platform:rpm]
+python3-libsemanage [platform:rpm]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+selinux


### PR DESCRIPTION
##### SUMMARY
The https://github.com/ansible/ansible-builder tool under development creates execution container images from a list of collections, and pre-loads the image with the collections and the dependencies needed to run their modules & plugins.

I went through thing listed in the `requirements:` entry of DOCUMENTATION strings here, you can see those here:

https://github.com/AlanCoding/collection-dependencies-demo/blob/dd568760a0ccc8fe5c38ca149e78e62ca6af50bb/sniff_req/discovered.json#L169-L179

Many of these are plain-english descriptions of something that's needed.

I've taken the actionable (installable) packages mentioned there and put them a format that will be recognized by ansible-builder. This will still require https://github.com/ansible/ansible-builder/pull/59 to fully work.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
N/A

##### ADDITIONAL INFORMATION
These files can still be moved around if desired.

I saw that there was no real overlap with `test-requirements.txt`
