### PR TITLE
Fix sanity test failures

### DIFF
--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -3,7 +3,6 @@ plugins/module_utils/firewalld.py metaclass-boilerplate
 plugins/module_utils/mount.py future-import-boilerplate
 plugins/module_utils/mount.py metaclass-boilerplate
 plugins/modules/acl.py validate-modules:parameter-type-not-in-doc
-plugins/modules/patch.py pylint:blacklisted-name
 plugins/modules/synchronize.py pylint:blacklisted-name
 plugins/modules/synchronize.py use-argspec-type-path
 plugins/modules/synchronize.py validate-modules:doc-default-does-not-match-spec

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -142,7 +142,7 @@ function cleanup
             ansible-test coverage xml --color --requirements --group-by command --group-by version ${stub:+"$stub"}
             cp -a tests/output/reports/coverage=*.xml "$SHIPPABLE_RESULT_DIR/codecoverage/"
 
-            if ! [[ "${x}" =~ "2.9" ]]; then
+            if ! [[ "${ansible_version}" =~ 2.9 ]]; then
                 # analyze and capture code coverage aggregated by integration test target
                 ansible-test coverage analyze targets generate -v "$SHIPPABLE_RESULT_DIR/testresults/coverage-analyze-targets.json"
             fi


### PR DESCRIPTION
##### SUMMARY
Remove no longer necessary ignore
Fix shippable.sh to use correct ansible_version variable and don't
quote pattern to be matched by =~

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/utils/shippable/shippable.sh
tests/sanity/ignore-2.10.txt

