### PR TITLE
Updated description of `use_ssh_args` option for synchronize.py

### DIFF
--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -138,7 +138,7 @@ options:
     default: yes
   use_ssh_args:
     description:
-      - Use the ssh_args specified in ansible.cfg.
+      - Use the ssh_args specified in ansible.cfg. Setting this to `yes` will also make `synchronize` use `ansible_ssh_common_args`.
     type: bool
     default: no
   rsync_opts:


### PR DESCRIPTION
This option has interactions with `ansible_ssh_common_args` as indicated in this issue thread: https://github.com/ansible/ansible/issues/16767

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
