### PR TITLE
at: add support for AIX

### DIFF
--- a/plugins/modules/at.py
+++ b/plugins/modules/at.py
@@ -74,6 +74,7 @@ EXAMPLES = r'''
 '''
 
 import os
+import platform
 import tempfile
 
 from ansible.module_utils.basic import AnsibleModule
@@ -89,7 +90,7 @@ def add_job(module, result, at_cmd, count, units, command, script_file):
 
 def delete_job(module, result, at_cmd, command, script_file):
     for matching_job in get_matching_jobs(module, at_cmd, script_file):
-        at_command = "%s -d %s" % (at_cmd, matching_job)
+        at_command = "%s -r %s" % (at_cmd, matching_job)
         rc, out, err = module.run_command(at_command, check_rc=True)
         result['changed'] = True
     if command:
@@ -117,7 +118,8 @@ def get_matching_jobs(module, at_cmd, script_file):
     #   If the script text is contained in a job add job number to list.
     for current_job in current_jobs:
         split_current_job = current_job.split()
-        at_command = "%s -c %s" % (at_cmd, split_current_job[0])
+        at_opt = '-c' if platform.system() != 'AIX' else '-lv'
+        at_command = "%s %s %s" % (at_cmd, at_opt, split_current_job[0])
         rc, out, err = module.run_command(at_command, check_rc=True)
         if script_file_string in out:
             matching_jobs.append(split_current_job[0])


### PR DESCRIPTION
### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The `at` module does not work correctly on AIX.
Trying to remove a job fails with a syntax error.
Setting the `unique` attribute to `yes` also fails.
AIX uses `-lv` options to cat a job (instead of `-c` for Linux) and `-r` to remove a job.
Linux supports both `-r` and `-d`, so use `-r` since it is what POSIX says.
See https://www.ibm.com/support/knowledgecenter/ssw_aix_72/a_commands/at.html and https://pubs.opengroup.org/onlinepubs/9699919799/utilities/at.html
Other systems like SunOS or the BSDs also appear to use `-r` to remove a job.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
at

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
To recreate the issue, use the following playbook:
```
- hosts: aix
  gather_facts: no
  tasks:
  - at:
      command: "ls -d / > /dev/null"
      state: absent
```
This fails with:
```
fatal: [aix-host1]: FAILED! => {
    "changed": false,
    "cmd": "/usr/bin/at -c root.1599830992c0.a",
    "invocation": {
        "module_args": {
            "command": "ls -d / > /dev/null",
            "count": null,
            "script_file": null,
            "state": "absent",
            "unique": false,
            "units": null
        }
    },
    "msg": "at: syntax error",
    "rc": 1,
    "stderr": "at: syntax error\n",
    "stderr_lines": [
        "at: syntax error"
    ],
    "stdout": "",
    "stdout_lines": []
}
```