### PR TITLE
do not persist sysctl when value is invalid

### DIFF
--- a/plugins/modules/sysctl.py
+++ b/plugins/modules/sysctl.py
@@ -182,12 +182,12 @@ class SysctlModule(object):
 
         # Do the work
         if not self.module.check_mode:
+            if self.set_proc:
+                self.set_token_value(self.args['name'], self.args['value'])
             if self.write_file:
                 self.write_sysctl()
             if self.changed and self.args['reload']:
                 self.reload_sysctl()
-            if self.set_proc:
-                self.set_token_value(self.args['name'], self.args['value'])
 
     def _values_is_equal(self, a, b):
         """Expects two string values. It will split the string by whitespace

--- a/tests/integration/targets/sysctl/tasks/main.yml
+++ b/tests/integration/targets/sysctl/tasks/main.yml
@@ -289,3 +289,24 @@
           - sysctl_check_mode2 is changed
           - "'vm.swappiness=22' in sysctl_check_mode_conf_content.stdout_lines"
           - sysctl_check_mode_current_vm_swappiness.stdout == '22'
+
+    # Test sysctl: invalid value
+    - name: Set invalid sysctl property using module
+      sysctl:
+        name: vm.mmap_rnd_bits
+        value: '1024'
+        state: present
+        reload: yes
+        sysctl_set: True
+      ignore_errors: True
+      register: sysctl_invalid_set1
+
+    - name: Read /etc/sysctl.conf
+      command: 'cat /etc/sysctl.conf'
+      register: sysctl_invalid_conf_content
+
+    - name: Ensure changes were not made
+      assert:
+        that:
+          - sysctl_invalid_set1 is failed
+          - "'vm.mmap_rnd_bits' not in sysctl_invalid_conf_content.stdout"


### PR DESCRIPTION
##### SUMMARY
the order of actions for setting, persisting and activation is changed,
to not persist an invalid sysctl value. This is only enforced when
sysct_set is True.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
sysctl

##### ADDITIONAL INFORMATION
we had some "fun" with the original behaviour in this PR: https://github.com/dev-sec/ansible-os-hardening/pull/312

Once a invalid value is persisted every change of a sysctl (with a reload) triggers an error. This complecates debugging and makes the real error non obvious for the user.

Playbook:
```yaml
- hosts: localhost
  tasks:
    - name: Set sysctl property using module
      sysctl:
        name: vm.mmap_rnd_bits
        value: '1024'
        state: present
        reload: yes
        sysctl_set: True
```

Before:
```
# ansible-playbook -vvv test.yml
...
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "ignoreerrors": false,
            "name": "vm.mmap_rnd_bits",
            "reload": true,
            "state": "present",
            "sysctl_file": "/etc/sysctl.conf",
            "sysctl_set": true,
            "value": "1024"
        }
    },
    "msg": "Failed to reload sysctl: vm.mmap_rnd_bits = 1024\nsysctl: setting key \"vm.mmap_rnd_bits\": Invalid argument\n"
# grep mmap /etc/sysctl.conf
vm.mmap_rnd_bits=1024
```

After
```
# ansible-playbook -vvv test.yml
...
fatal: [localhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "ignoreerrors": false,
            "name": "vm.mmap_rnd_bits",
            "reload": true,
            "state": "present",
            "sysctl_file": "/etc/sysctl.conf",
            "sysctl_set": true,
            "value": "1024"
        }
    },
    "msg": "setting vm.mmap_rnd_bits failed: vm.mmap_rnd_bits = 1024\nsysctl: setting key \"vm.mmap_rnd_bits\": Invalid argument\n"
# grep mmap /etc/sysctl.conf
```
