### PR TITLE
Fix module in order to don't show "changed" status when running ansib…

### DIFF
--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -618,9 +618,12 @@ def enforce_state(module, params):
     # for 'exclusive', make sure keys are written in the order the new keys were
     if state == "present" and exclusive:
         to_remove = frozenset(existing_keys).difference(keys_to_exist)
-        for key in to_remove:
-            del existing_keys[key]
-            do_write = True
+        if len(to_remove) != 0:
+            for key in to_remove:
+                del existing_keys[key]
+                do_write = True
+        else:
+            do_write = False
 
     if do_write:
         filename = keyfile(module, user, do_write, path, manage_dir, follow)


### PR DESCRIPTION
…le playbook with authorized_key module if keys are not different

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When running ansible playbook with this module, even if keys are not different, it shows "changed" status instead of "ok".
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
authorized_key.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
To reproduce :
Run a playbook using this module without fix
Run it again
See it shows "changed", but nothing changed
Run it with fix
No "changed" anymore
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
