### PR TITLE
Bugfix for #17492 "Do not prepend PWD when path is in form user@server:path or server:path" 

### DIFF
--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -33,7 +33,13 @@ class ActionModule(ActionBase):
     def _get_absolute_path(self, path):
         original_path = path
 
-        if path.startswith('rsync://'):
+        #
+        # Check if we have a local relative path and do not process
+        # * remote paths (some.server.domain:/some/remote/path/...)
+        # * URLs (rsync://...)
+        # * local absolute paths (/some/local/path/...)
+        #
+        if ':' in path or path.startswith('/'):
             return path
 
         if self._task._role is not None:
@@ -73,8 +79,7 @@ class ActionModule(ActionBase):
         if host not in C.LOCALHOST:
             return self._format_rsync_rsh_target(host, path, user)
 
-        if ':' not in path and not path.startswith('/'):
-            path = self._get_absolute_path(path=path)
+        path = self._get_absolute_path(path=path)
         return path
 
     def _process_remote(self, task_args, host, path, user, port_matches_localhost_port):
@@ -103,8 +108,7 @@ class ActionModule(ActionBase):
                 task_args['_substitute_controller'] = True
             return self._format_rsync_rsh_target(host, path, user)
 
-        if ':' not in path and not path.startswith('/'):
-            path = self._get_absolute_path(path=path)
+        path = self._get_absolute_path(path=path)
         return path
 
     def _override_module_replaced_vars(self, task_vars):
@@ -348,10 +352,8 @@ class ActionModule(ActionBase):
         else:
             # Still need to munge paths (to account for roles) even if we aren't
             # copying files between hosts
-            if not src.startswith('/'):
-                src = self._get_absolute_path(path=src)
-            if not dest.startswith('/'):
-                dest = self._get_absolute_path(path=dest)
+            src = self._get_absolute_path(path=src)
+            dest = self._get_absolute_path(path=dest)
 
         _tmp_args['src'] = src
         _tmp_args['dest'] = dest


### PR DESCRIPTION
##### SUMMARY
This fixes the old [bug #17492: "Do not prepend PWD when path is in form user@server:path or server:path"](https://github.com/ansible/ansible/issues/17492) (again).
Fix was already in the [ansible/ansible repo pull request 33998](https://github.com/ansible/ansible/pull/33998) as of December 2017, but never got merged.

There are several instances where the `_get_absolute_path` function is called. This should only happen for relative paths on a local file system and hence

* not for paths on a remote server
* nor for absolute paths.

The synchronize.py plugin checked before calling this function whether it was necessary to call `_get_absolute_path`.
It should not convert a path to an absolute path when it:

* contains a colon (path on remote server) or
* starts with a slash forward (absolute path).

In some cases the code would perform both checks and in some it failed to check for _remote paths_. This results in ${PWD} getting prepended to the remote path leading to something like /path/to/PWD/user@server:/path/to/what/needs/to/be/synced.

In this pull request the the two checks for _remote paths_ and _absolute paths_ are relocated to the `_get_absolute_path` function to remove code redundancy and to ensure the paths are always checked before trying to convert a local relative path into an absolute one.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
synchronize plugin

##### ADDITIONAL INFORMATION
Bug happens when using synchronize in `pull` mode. E.g.
```
synchronize: mode=pull src=rsync://somehost.com/path/ dest=/some/absolute/path/
```
will fail in any Ansible version with something like:
```
failed rsync from ${PWD}rsync://somehost.com/path/
```
