### PR TITLE
Bugfix for #24365: "Added option to allow SSH connection multiplexing"

### DIFF
--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -147,8 +147,8 @@ options:
         This is accomplished by setting the SSH C(ControlSocket) to C(none).
       - Set this option to C(yes) to allow multiplexing and reduce SSH connection overhead.
       - Note that simply setting this option to C(yes) is not enough;
-        You must also configure SSH connection multiplexing in your SSH client config by setting values for C(ControlMaster), 
-        C(ControlPersist) and C(ControlPath).
+        You must also configure SSH connection multiplexing in your SSH client config by setting values for
+        C(ControlMaster), C(ControlPersist) and C(ControlPath).
     type: bool
     default: no
   rsync_opts:

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -141,6 +141,16 @@ options:
       - Use the ssh_args specified in ansible.cfg. Setting this to `yes` will also make `synchronize` use `ansible_ssh_common_args`.
     type: bool
     default: no
+  ssh_connection_multiplexing:
+    description:
+      - SSH connection multiplexing for rsync is disabled by default to prevent misconfigured ControlSockets from resulting in failed SSH connections.
+        This is accomplished by setting the SSH C(ControlSocket) to C(none).
+      - Set this option to C(yes) to allow multiplexing and reduce SSH connection overhead.
+      - Note that simply setting this option to C(yes) is not enough;
+        You must also configure SSH connection multiplexing in your SSH client config by setting values for C(ControlMaster), 
+        C(ControlPersist) and C(ControlPath).
+    type: bool
+    default: no
   rsync_opts:
     description:
       - Specify additional rsync options by passing in an array.
@@ -392,6 +402,7 @@ def main():
             rsync_timeout=dict(type='int', default=0),
             rsync_opts=dict(type='list', default=[]),
             ssh_args=dict(type='str'),
+            ssh_connection_multiplexing=dict(type='bool', default=False),
             partial=dict(type='bool', default=False),
             verify_host=dict(type='bool', default=False),
             mode=dict(type='str', default='push', choices=['pull', 'push']),
@@ -432,6 +443,7 @@ def main():
     group = module.params['group']
     rsync_opts = module.params['rsync_opts']
     ssh_args = module.params['ssh_args']
+    ssh_connection_multiplexing = module.params['ssh_connection_multiplexing']
     verify_host = module.params['verify_host']
     link_dest = module.params['link_dest']
 
@@ -507,7 +519,9 @@ def main():
 
         # if the user has not supplied an --rsh option go ahead and add ours
         if not has_rsh:
-            ssh_cmd = [module.get_bin_path('ssh', required=True), '-S', 'none']
+            ssh_cmd = [module.get_bin_path('ssh', required=True)]
+            if not ssh_connection_multiplexing:
+                ssh_cmd.extend(['-S', 'none'])
             if private_key is not None:
                 ssh_cmd.extend(['-i', private_key])
             # If the user specified a port value


### PR DESCRIPTION
##### SUMMARY

Removed hard-coded ssh control path `"none"` to make sure `synchronize` module respects `ansible_ssh_common_args`. When users want to configure (disable/enable) connection multiplexing they can do so either in Ansible (`ansible.cfg`) or in their SSH config outside Ansible (`~/.ssh/config`). Either way the synchronize module should respect that and not override the ability to use connection multiplexing by setting the control path to `"none"`.

Fixes [bug #24365](https://github.com/ansible/ansible/issues/24365)

This is a new attempt to get rid off this long standing bug and now includes an option to allow or disable SSH connection multiplexing. For historic reasons the default is set to disable connection multiplexing, which ensures playbooks that rely on the old behavior of hard-coded disabling connection multiplexing won't break. Hard-coded disabling of the control socket for connection multiplexing was introduced as a "fix" for [conflicting control sockets](https://github.com/ansible/ansible/issues/8473), but it's a workaround at best and causes new problems. 

In the best case scenario bug #24365 results in slow plays due to the extra overhead of creating a new SSH session for each and every item you try to synchronize. In the worst case scenario bug #24365 breaks a play. This will happen for example when the remote rsync server uses SSH rate limiting, which is a common security feature. In my case I'm synchronizing relatively large files. The first time a playbook is run, `synchronize` will work as there is enough time in between the SSH connections made. But when I run the playbook again and rsync only needs to transfer small changes/updates, the playbook makes too many SSH connections in too little time, resulting in a temporary IP ban. It then takes 24 hours to get removed from a blacklist before the playbook will work again.... once before it breaks again: not very idempotent. Disabling connection multiplexing is also problematic when the remote rsync server requires 2FA logins: typing a 6 digit code once is Ok, but not for each and every item again and again.

Note that the current hard-coded disabling of SSH connection multiplexing also conflicts with the `use_ssh_args` option for the `synchronize` module, which claims to _"Use the ssh_args specified in ansible.cfg."_

The bottom line: if connection multiplexing does not work, then either fix your connection multiplexing settings or just don't use it at all, but do not force all Ansible users to do without connection multiplexing just because some Ansible users want to use a broken SSH configuration.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

synchronize module

##### ADDITIONAL INFORMATION

* The previous pull request: [Do not disable SSH connection sharing for synchronize](https://github.com/ansible/ansible/pull/41332)
* Related work: https://github.com/cognifloyd/ansible/commit/1159455d0692a39ba6132644c1a150ab71c0453a