### PR TITLE
mount return backup_file

### DIFF
--- a/changelogs/fragments/126_mount_not_returning_backup_file.yml
+++ b/changelogs/fragments/126_mount_not_returning_backup_file.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mount - returns ``backup_file`` value when a backup fstab is created.

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -109,128 +109,110 @@
     - unmount_result['changed']
     - not dest_stat['stat']['exists']
   when: ansible_system in ('FreeBSD', 'Linux')
-- name: Create fstab record for the first swap file
-  mount:
-    name: none
-    src: /tmp/swap1
-    opts: sw
-    fstype: swap
-    state: present
-  register: swap1_created
-  when: ansible_system in ('Linux')
-- name: Try to create fstab record for the first swap file again
-  mount:
-    name: none
-    src: /tmp/swap1
-    opts: sw
-    fstype: swap
-    state: present
-  register: swap1_created_again
-  when: ansible_system in ('Linux')
-- name: Check that we created the swap1 record
-  assert:
-    that:
-    - swap1_created['changed']
-    - not swap1_created_again['changed']
-  when: ansible_system in ('Linux')
-- name: Create fstab record for the second swap file
-  mount:
-    name: none
-    src: /tmp/swap2
-    opts: sw
-    fstype: swap
-    state: present
-  register: swap2_created
-  when: ansible_system in ('Linux')
-- name: Try to create fstab record for the second swap file again
-  mount:
-    name: none
-    src: /tmp/swap1
-    opts: sw
-    fstype: swap
-    state: present
-  register: swap2_created_again
-  when: ansible_system in ('Linux')
-- name: Check that we created the swap2 record
-  assert:
-    that:
-    - swap2_created['changed']
-    - not swap2_created_again['changed']
-  when: ansible_system in ('Linux')
-- name: Remove the fstab record for the first swap file
-  mount:
-    name: none
-    src: /tmp/swap1
-    state: absent
-  register: swap1_removed
-  when: ansible_system in ('Linux')
-- name: Try to remove the fstab record for the first swap file again
-  mount:
-    name: none
-    src: /tmp/swap1
-    state: absent
-  register: swap1_removed_again
-  when: ansible_system in ('Linux')
-- name: Check that we removed the swap1 record
-  assert:
-    that:
-    - swap1_removed['changed']
-    - not swap1_removed_again['changed']
-  when: ansible_system in ('Linux')
-- name: Remove the fstab record for the second swap file
-  mount:
-    name: none
-    src: /tmp/swap2
-    state: absent
-  register: swap2_removed
-  when: ansible_system in ('Linux')
-- name: Try to remove the fstab record for the second swap file again
-  mount:
-    name: none
-    src: /tmp/swap2
-    state: absent
-  register: swap2_removed_again
-  when: ansible_system in ('Linux')
-- name: Check that we removed the swap2 record
-  assert:
-    that:
-    - swap2_removed['changed']
-    - not swap2_removed_again['changed']
-  when: ansible_system in ('Linux')
-- name: Create fstab record with missing last two fields
-  copy:
-    dest: /etc/fstab
-    content: '//nas/photo /home/jik/pictures cifs defaults,credentials=/etc/security/nas.creds,uid=jik,gid=users,forceuid,forcegid,noserverino,_netdev
-
-      '
-  when: ansible_system in ('Linux')
-- name: Try to change the fstab record with the missing last two fields
-  mount:
-    src: //nas/photo
-    path: /home/jik/pictures
-    fstype: cifs
-    opts: defaults,credentials=/etc/security/nas.creds,uid=jik,gid=users,forceuid,forcegid,noserverino,_netdev,x-systemd.mount-timeout=0
-    state: present
-  register: optional_fields_update
-  when: ansible_system in ('Linux')
-- name: Get the content of the fstab file
-  shell: cat /etc/fstab
-  register: optional_fields_content
-  when: ansible_system in ('Linux')
-- name: Check if the line containing the missing last two fields was changed
-  assert:
-    that:
-    - optional_fields_update['changed']
-    - ''' 0 0'' in optional_fields_content.stdout'
-    - 1 == optional_fields_content.stdout_lines | length
-  when: ansible_system in ('Linux')
 - name: Block to test remounted option
   block:
+  - name: Create fstab record for the first swap file
+    mount:
+      name: none
+      src: /tmp/swap1
+      opts: sw
+      fstype: swap
+      state: present
+    register: swap1_created
+  - name: Try to create fstab record for the first swap file again
+    mount:
+      name: none
+      src: /tmp/swap1
+      opts: sw
+      fstype: swap
+      state: present
+    register: swap1_created_again
+  - name: Check that we created the swap1 record
+    assert:
+      that:
+      - swap1_created['changed']
+      - not swap1_created_again['changed']
+  - name: Create fstab record for the second swap file
+    mount:
+      name: none
+      src: /tmp/swap2
+      opts: sw
+      fstype: swap
+      state: present
+    register: swap2_created
+  - name: Try to create fstab record for the second swap file again
+    mount:
+      name: none
+      src: /tmp/swap1
+      opts: sw
+      fstype: swap
+      state: present
+    register: swap2_created_again
+  - name: Check that we created the swap2 record
+    assert:
+      that:
+      - swap2_created['changed']
+      - not swap2_created_again['changed']
+  - name: Remove the fstab record for the first swap file
+    mount:
+      name: none
+      src: /tmp/swap1
+      state: absent
+    register: swap1_removed
+  - name: Try to remove the fstab record for the first swap file again
+    mount:
+      name: none
+      src: /tmp/swap1
+      state: absent
+    register: swap1_removed_again
+  - name: Check that we removed the swap1 record
+    assert:
+      that:
+      - swap1_removed['changed']
+      - not swap1_removed_again['changed']
+  - name: Remove the fstab record for the second swap file
+    mount:
+      name: none
+      src: /tmp/swap2
+      state: absent
+    register: swap2_removed
+  - name: Try to remove the fstab record for the second swap file again
+    mount:
+      name: none
+      src: /tmp/swap2
+      state: absent
+    register: swap2_removed_again
+  - name: Check that we removed the swap2 record
+    assert:
+      that:
+      - swap2_removed['changed']
+      - not swap2_removed_again['changed']
+  - name: Create fstab record with missing last two fields
+    copy:
+      dest: /etc/fstab
+      content: '//nas/photo /home/jik/pictures cifs defaults,credentials=/etc/security/nas.creds,uid=jik,gid=users,forceuid,forcegid,noserverino,_netdev
+
+        '
+  - name: Try to change the fstab record with the missing last two fields
+    mount:
+      src: //nas/photo
+      path: /home/jik/pictures
+      fstype: cifs
+      opts: defaults,credentials=/etc/security/nas.creds,uid=jik,gid=users,forceuid,forcegid,noserverino,_netdev,x-systemd.mount-timeout=0
+      state: present
+    register: optional_fields_update
+  - name: Get the content of the fstab file
+    shell: cat /etc/fstab
+    register: optional_fields_content
+  - name: Check if the line containing the missing last two fields was changed
+    assert:
+      that:
+      - optional_fields_update['changed']
+      - ''' 0 0'' in optional_fields_content.stdout'
+      - 1 == optional_fields_content.stdout_lines | length
   - name: Create empty file
     command: dd if=/dev/zero of=/tmp/myfs.img bs=1048576 count=20
-    when: ansible_system in ('Linux')
   - name: Format FS
-    when: ansible_system in ('Linux')
     community.general.system.filesystem:
       fstype: ext3
       dev: /tmp/myfs.img
@@ -240,44 +222,48 @@
       src: /tmp/myfs.img
       fstype: ext2
       state: mounted
-    when: ansible_system in ('Linux')
   - name: Get the last write time
     shell: 'dumpe2fs /tmp/myfs.img 2>/dev/null | grep -i last write time: |cut -d: -f2-'
     register: last_write_time
-    when: ansible_system in ('Linux')
   - name: Wait 2 second
     pause:
       seconds: 2
-    when: ansible_system in ('Linux')
   - name: Test if the FS is remounted
     mount:
       path: /tmp/myfs
       state: remounted
-    when: ansible_system in ('Linux')
   - name: Get again the last write time
     shell: 'dumpe2fs /tmp/myfs.img 2>/dev/null | grep -i last write time: |cut -d: -f2-'
     register: last_write_time2
-    when: ansible_system in ('Linux')
   - name: Fail if they are the same
     fail:
       msg: Filesytem was not remounted, testing of the module failed!
-    when: last_write is defined and last_write_time2 is defined and last_write_time.stdout == last_write_time2.stdout and ansible_system in ('Linux')
+    when: last_write is defined and last_write_time2 is defined and last_write_time.stdout == last_write_time2.stdout 
   - name: Remount filesystem with different opts using remounted option (Linux only)
     mount:
       path: /tmp/myfs
       state: remounted
       opts: rw,noexec
-    when: ansible_system == 'Linux'
   - name: Get remounted options (Linux only)
     shell: mount | grep myfs | grep -E -w 'noexec' | wc -l
     register: remounted_options
-    when: ansible_system == 'Linux'
   - name: Make sure the filesystem now has the new opts after using remounted (Linux only)
     assert:
       that:
         - "'1' in remounted_options.stdout"
         - "1 == remounted_options.stdout_lines | length"
-    when: ansible_system == 'Linux'
+  - name: Mount the FS again to test backup
+    mount:
+      path: /tmp/myfs
+      src: /tmp/myfs.img
+      fstype: ext2
+      state: mounted
+      backup: yes
+    register: mount_backup_out
+  - name: ensure backup_file in returned output
+    assert:
+      that:
+        - "'backup_file' in mount_backup_out"
   always:
   - name: Umount the test FS
     mount:
@@ -285,7 +271,6 @@
       src: /tmp/myfs.img
       opts: loop
       state: absent
-    when: ansible_system in ('Linux')
   - name: Remove the test FS
     file:
       path: '{{ item }}'
@@ -293,4 +278,4 @@
     loop:
     - /tmp/myfs.img
     - /tmp/myfs
-    when: ansible_system in ('Linux')
+  when: ansible_system in ('Linux')


### PR DESCRIPTION
Signed-off-by: Adam Miller <admiller@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
 The mount module now returns `backup_file` when one is created for fstab. 

Fixes https://github.com/ansible-collections/ansible.posix/issues/126

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mount 

