### PR TITLE
firewalld: Add support for firewalld port forwarding

### DIFF
--- a/docs/ansible.posix.firewalld_module.rst
+++ b/docs/ansible.posix.firewalld_module.rst
@@ -176,6 +176,21 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>port_forward</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Port and protocol to forward using firewalld.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>rich_rule</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -360,14 +375,17 @@ Examples
         permanent: yes
         icmp_block: echo-request
 
-    - name: Redirect port 443 to 8443 with Rich Rule
+    - name: Redirect port 443 to 8443
+      become: yes
       ansible.posix.firewalld:
-        rich_rule: rule family=ipv4 forward-port port=443 protocol=tcp to-port=8443
+        port_forward:
+          - port: 443
+            proto: tcp
+            toport: 8443
         zone: public
         permanent: yes
         immediate: yes
         state: enabled
-
 
 
 

--- a/tests/integration/targets/firewalld/tasks/port_forward_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/port_forward_test_cases.yml
@@ -1,0 +1,77 @@
+# Test playbook for the firewalld module - port operations
+# (c) 2017, Adam Miller <admiller@redhat.com>
+
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+- name: firewalld port forward test permanent enabled
+  firewalld:
+    port_forward:
+      - port: 8080
+        proto: tcp
+        toport: 8081
+    permanent: true
+    state: enabled
+  register: result
+
+- name: assert firewalld port test permanent enabled worked
+  assert:
+    that:
+    - result is changed
+
+- name: firewalld port test permanent enabled rerun (verify not changed)
+  firewalld:
+    port_forward:
+      - port: 8080
+        proto: tcp
+        toport: 8081
+    permanent: true
+    state: enabled
+  register: result
+
+- name: assert firewalld port test permanent enabled rerun worked (verify not changed)
+  assert:
+    that:
+    - result is not changed
+
+- name: firewalld port test permanent disabled
+  firewalld:
+    port_forward:
+      - port: 8080
+        proto: tcp
+        toport: 8081
+    permanent: true
+    state: disabled
+  register: result
+
+- name: assert firewalld port test permanent disabled worked
+  assert:
+    that:
+    - result is changed
+
+- name: firewalld port test permanent disabled rerun (verify not changed)
+  firewalld:
+    port_forward:
+      - port: 8080
+        proto: tcp
+        toport: 8081
+    permanent: true
+    state: disabled
+  register: result
+
+- name: assert firewalld port test permanent disabled rerun worked (verify not changed)
+  assert:
+    that:
+    - result is not changed


### PR DESCRIPTION
##### SUMMARY

Implement support in firewalld for use of the port forward API. Previously, the only way to forward ports using ansible was with the rich rule syntax. This change adds the `port_forward` parameter to manage port forwards directly.  The naming scheme for the parameter list is the same as existing firewalld naming. I opted to use a subgroup to clearly delineate the options and support better validation of the protocol parameter. 

Fixes: ansible-collections/ansible.posix#100
##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
firewalld

##### ADDITIONAL INFORMATION
