### PR TITLE
AZP: Ensure collection dir is writable

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -14,6 +14,9 @@ function join {
     echo "$*";
 }
 
+# Ensure we can write other collections to this dir
+sudo chown "$(whoami)" "${PWD}/../../"
+
 test="$(join / "${args[@]:1}")"
 
 docker images ansible/ansible


### PR DESCRIPTION
##### SUMMARY
`ansible-galaxy collection install` is currently failing, likely as the chown isn't present

##### ISSUE TYPE
- Bugfix Pull Request
