### PR TITLE
selinux: update kernel boot params when disabling/re-enabling SELinux

### DIFF
--- a/changelogs/fragments/disable_selinux_via_kernel_cmdline.yml
+++ b/changelogs/fragments/disable_selinux_via_kernel_cmdline.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- selinux - optionally update kernel boot params when disabling/re-enabling SELinux (https://github.com/ansible-collections/ansible.posix/pull/142).

--- a/tests/integration/targets/selinux/tasks/selinux.yml
+++ b/tests/integration/targets/selinux/tasks/selinux.yml
@@ -20,6 +20,11 @@
 # ##############################################################################
 # Test changing the state, which requires a reboot
 
+- name: TEST 1 | Make sure grubby is present
+  package:
+    name: grubby
+    state: present
+
 - name: TEST 1 | Get current SELinux config file contents
   set_fact:
     selinux_config_original: "{{ lookup('file', '/etc/sysconfig/selinux').split('\n') }}"
@@ -104,10 +109,51 @@
       - selinux_config_after[selinux_config_after.index('SELINUX=disabled')]  is search("^SELINUX=\w+$")
       - selinux_config_after[selinux_config_after.index('SELINUXTYPE=targeted')]  is search("^SELINUXTYPE=\w+$")
 
-- name: TEST 1 | Reset SELinux configuration for next test
+- name: TEST 1 | Disable SELinux again, with kernel arguments update
+  selinux:
+    state: disabled
+    policy: targeted
+    update_kernel_param: true
+  register: _disable_test2
+
+- name: Check kernel command-line arguments
+  ansible.builtin.command: grubby --info=DEFAULT
+  register: _grubby_test1
+
+- name: TEST 1 | Assert that kernel cmdline contains selinux=0
+  assert:
+    that:
+      - "' selinux=0' in _grubby_test1.stdout"
+
+- name: TEST 1 | Enable SELinux, without kernel arguments update
+  selinux:
+    state: disabled
+    policy: targeted
+  register: _disable_test2
+
+- name: Check kernel command-line arguments
+  ansible.builtin.command: grubby --info=DEFAULT
+  register: _grubby_test1
+
+- name: TEST 1 | Assert that kernel cmdline still contains selinux=0
+  assert:
+    that:
+      - "' selinux=0' in _grubby_test1.stdout"
+
+- name: TEST 1 | Reset SELinux configuration for next test (also kernel args)
   selinux:
     state: enforcing
+    update_kernel_param: true
     policy: targeted
+
+- name: Check kernel command-line arguments
+  ansible.builtin.command: grubby --info=DEFAULT
+  register: _grubby_test2
+
+- name: TEST 1 | Assert that kernel cmdline doesn't contain selinux=0
+  assert:
+    that:
+      - "' selinux=0' not in _grubby_test2.stdout"
 
 
 # Second Test


### PR DESCRIPTION
##### SUMMARY

The ability to disable SELinux from userspace based on the configuration
file is being deprecated in favor of the selinux=0 kernel boot
parameter. (Note that this affects only the "full" disable; switching
to/from permissive mode will work the same as before.)

Therefore, enhance the selinux module to try to set/unset the kernel
command-line parameter using grubby when enabling/disabling SELinux.

If the grubby package is not present on the system, the module will only
update the config file and report a warning. Note that even with the
runtime disable functionality removed, setting SELINUX=disabled in the
config file will lead to a system with no SELinux policy loaded, which
will behave in a very similar way as if SELinux was fully disabled, only
there could still be some minor performance impact, since the kernel
hooks will still be active.

More information:
https://lore.kernel.org/selinux/157836784986.560897.13893922675143903084.stgit@chester/
https://fedoraproject.org/wiki/Changes/Remove_Support_For_SELinux_Runtime_Disable

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
selinux module
