### PR TITLE
Inform synchronize module about community.docker collection

### DIFF
--- a/changelogs/fragments/144_add_community_docker_connection_plugin_alias.yml
+++ b/changelogs/fragments/144_add_community_docker_connection_plugin_alias.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - synchronize - add ``community.docker.docker`` to the list of supported
+    transports (https://github.com/ansible-collections/ansible.posix/issues/132).

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -60,7 +60,7 @@ class ActionModule(ActionBase):
             return path
 
         # If using docker or buildah, do not add user information
-        if self._remote_transport not in ['docker', 'community.general.docker', 'buildah', 'containers.podman.buildah'] and user:
+        if self._remote_transport not in ['docker', 'community.general.docker', 'community.docker.docker', 'buildah', 'containers.podman.buildah'] and user:
             user_prefix = '%s@' % (user, )
 
         if self._host_is_ipv6_address(host):
@@ -170,7 +170,7 @@ class ActionModule(ActionBase):
         self._remote_transport = self._connection.transport
 
         # Handle docker connection options
-        if self._remote_transport in ['docker', 'community.general.docker']:
+        if self._remote_transport in ['docker', 'community.general.docker', 'community.docker.docker']:
             self._docker_cmd = self._connection.docker_cmd
             if self._play_context.docker_extra_args:
                 self._docker_cmd = "%s %s" % (self._docker_cmd, self._play_context.docker_extra_args)
@@ -192,7 +192,7 @@ class ActionModule(ActionBase):
         # ssh paramiko docker buildah and local are fully supported transports.  Anything
         # else only works with delegate_to
         if delegate_to is None and self._connection.transport not in \
-                ('ssh', 'paramiko', 'local', 'docker', 'community.general.docker', 'buildah', 'containers.podman.buildah'):
+                ('ssh', 'paramiko', 'local', 'docker', 'community.general.docker', 'community.docker.docker', 'buildah', 'containers.podman.buildah'):
             result['failed'] = True
             result['msg'] = (
                 "synchronize uses rsync to function. rsync needs to connect to the remote "
@@ -365,7 +365,7 @@ class ActionModule(ActionBase):
         if not dest_is_local:
             # don't escalate for docker. doing --rsync-path with docker exec fails
             # and we can switch directly to the user via docker arguments
-            if self._play_context.become and not rsync_path and self._remote_transport not in ['docker', 'community.general.docker']:
+            if self._play_context.become and not rsync_path and self._remote_transport not in ['docker', 'community.general.docker', 'community.docker.docker']:
                 # If no rsync_path is set, become was originally set, and dest is
                 # remote then add privilege escalation here.
                 if self._play_context.become_method == 'sudo':
@@ -389,7 +389,9 @@ class ActionModule(ActionBase):
 
         # If launching synchronize against docker container
         # use rsync_opts to support container to override rsh options
-        if self._remote_transport in ['docker', 'community.general.docker', 'buildah', 'containers.podman.buildah'] and not use_delegate:
+        if self._remote_transport in [
+            'docker', 'community.general.docker', 'community.docker.docker', 'buildah', 'containers.podman.buildah'
+        ] and not use_delegate:
             # Replicate what we do in the module argumentspec handling for lists
             if not isinstance(_tmp_args.get('rsync_opts'), MutableSequence):
                 tmp_rsync_opts = _tmp_args.get('rsync_opts', [])
@@ -402,7 +404,7 @@ class ActionModule(ActionBase):
             if '--blocking-io' not in _tmp_args['rsync_opts']:
                 _tmp_args['rsync_opts'].append('--blocking-io')
 
-            if self._remote_transport in ['docker', 'community.general.docker']:
+            if self._remote_transport in ['docker', 'community.general.docker', 'community.docker.docker']:
                 if become and self._play_context.become_user:
                     _tmp_args['rsync_opts'].append("--rsh=%s exec -u %s -i" % (self._docker_cmd, self._play_context.become_user))
                 elif user is not None:


### PR DESCRIPTION
##### SUMMARY
The synchronize action plugin has a built-in list of connection plugins that it knows how to handle.

One of those connection plugins is the docker connection plugin. And because the docker content has been moved around quite a lot, the docker connection plugin has quite a few names:

 - docker in Ansible 2.9,
 - community.general.docker for community.general < 2.0.0, and
 - community.docker.docker since a few months ago.

And while the synchronize module already knew about the first two names, the last one was still missing. This commit fixes that omission and adds a third name into the mix.

Fixes #132 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
synchronize