### PR TITLE
add no_log=False to clear false-positives

### DIFF
--- a/changelogs/fragments/156-fix_no-log-needed_false_positives.yml
+++ b/changelogs/fragments/156-fix_no-log-needed_false_positives.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - authorized_key - add ``no_log=False`` in ``argument_spec`` to clear false-positives of ``no-log-needed`` (https://github.com/ansible-collections/ansible.posix/pull/156).
+  - mount - add ``no_log=False`` in ``argument_spec`` to clear false-positives of ``no-log-needed`` (https://github.com/ansible-collections/ansible.posix/pull/156).

--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -648,11 +648,11 @@ def main():
     module = AnsibleModule(
         argument_spec=dict(
             user=dict(type='str', required=True),
-            key=dict(type='str', required=True),
+            key=dict(type='str', required=True, no_log=False),
             path=dict(type='path'),
             manage_dir=dict(type='bool', default=True),
             state=dict(type='str', default='present', choices=['absent', 'present']),
-            key_options=dict(type='str'),
+            key_options=dict(type='str', no_log=False),
             exclusive=dict(type='bool', default=False),
             comment=dict(type='str'),
             validate_certs=dict(type='bool', default=True),

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -648,7 +648,7 @@ def main():
             fstype=dict(type='str'),
             path=dict(type='path', required=True, aliases=['name']),
             opts=dict(type='str'),
-            passno=dict(type='str'),
+            passno=dict(type='str', no_log=False),
             src=dict(type='path'),
             backup=dict(type='bool', default=False),
             state=dict(type='str', required=True, choices=['absent', 'mounted', 'present', 'unmounted', 'remounted']),


### PR DESCRIPTION
##### SUMMARY

Ansible sanity test `validate-modules` triggers false-positives and hints `no-log-needed` errors for module parameters containing either `key` or `pass`in their names, as in:
```
2021-03-16 20:27:04.127992 | centos-8 | ERROR: Found 3 validate-modules issue(s) which need to be resolved:
2021-03-16 20:27:04.128105 | centos-8 | ERROR: plugins/modules/authorized_key.py:0:0: no-log-needed: Argument 'key' in argument_spec could be a secret, though doesn't have `no_log` set
2021-03-16 20:27:04.128204 | centos-8 | ERROR: plugins/modules/authorized_key.py:0:0: no-log-needed: Argument 'key_options' in argument_spec could be a secret, though doesn't have `no_log` set
2021-03-16 20:27:04.128303 | centos-8 | ERROR: plugins/modules/mount.py:0:0: no-log-needed: Argument 'passno' in argument_spec could be a secret, though doesn't have `no_log` set
```

This PR bypasses these errors by explicitly setting `no_log=False` in module's argument_spec.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

mount
authorized_key

##### ADDITIONAL INFORMATION

See also https://github.com/ansible-collections/community.network/commit/af60326281d0a193f57189dd44706e3aa9516797