### PR TITLE
Fix ansible_ssh_user

### DIFF
--- a/changelogs/fragments/159-fix-60-deprecated-ansible_ssh_user.yml
+++ b/changelogs/fragments/159-fix-60-deprecated-ansible_ssh_user.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - synchronize - replace old ``ansible_ssh_user`` by ``ansible_user`` everywhere; do the same for
+    ``ansible_ssh_port`` and ``ansible_ssh_host`` (https://github.com/ansible-collections/ansible.posix/issues/60).

--- a/changelogs/fragments/159-fix-60-deprecated-ansible_ssh_user.yml
+++ b/changelogs/fragments/159-fix-60-deprecated-ansible_ssh_user.yml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - synchronize - replace old ``ansible_ssh_user`` by ``ansible_user`` everywhere; do the same for
+  - synchronize - replace removed ``ansible_ssh_user`` by ``ansible_user`` everywhere; do the same for
     ``ansible_ssh_port`` and ``ansible_ssh_host`` (https://github.com/ansible-collections/ansible.posix/issues/60).

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -219,14 +219,10 @@ class ActionModule(ActionBase):
         src_host = '127.0.0.1'
         inventory_hostname = task_vars.get('inventory_hostname')
         dest_host_inventory_vars = task_vars['hostvars'].get(inventory_hostname)
-        try:
-            dest_host = dest_host_inventory_vars['ansible_host']
-        except KeyError:
-            dest_host = dest_host_inventory_vars.get('ansible_ssh_host', inventory_hostname)
+        dest_host = dest_host_inventory_vars.get('ansible_host', inventory_hostname)
 
         dest_host_ids = [hostid for hostid in (dest_host_inventory_vars.get('inventory_hostname'),
-                                               dest_host_inventory_vars.get('ansible_host'),
-                                               dest_host_inventory_vars.get('ansible_ssh_host'))
+                                               dest_host_inventory_vars.get('ansible_host'))
                          if hostid is not None]
 
         localhost_ports = set()
@@ -250,7 +246,7 @@ class ActionModule(ActionBase):
             dest_is_local = True
 
         # CHECK FOR NON-DEFAULT SSH PORT
-        inv_port = task_vars.get('ansible_ssh_port', None) or C.DEFAULT_REMOTE_PORT
+        inv_port = task_vars.get('ansible_port', None) or C.DEFAULT_REMOTE_PORT
         if _tmp_args.get('dest_port', None) is None:
             if inv_port is not None:
                 _tmp_args['dest_port'] = inv_port
@@ -327,14 +323,14 @@ class ActionModule(ActionBase):
             # Src and dest rsync "path" handling
             if boolean(_tmp_args.get('set_remote_user', 'yes'), strict=False):
                 if use_delegate:
-                    user = task_vars.get('ansible_delegated_vars', dict()).get('ansible_ssh_user', None)
+                    user = task_vars.get('ansible_delegated_vars', dict()).get('ansible_user', None)
                     if not user:
-                        user = task_vars.get('ansible_ssh_user') or self._play_context.remote_user
+                        user = task_vars.get('ansible_user') or self._play_context.remote_user
                     if not user:
                         user = C.DEFAULT_REMOTE_USER
 
                 else:
-                    user = task_vars.get('ansible_ssh_user') or self._play_context.remote_user
+                    user = task_vars.get('ansible_user') or self._play_context.remote_user
 
             # Private key handling
             # Use the private_key parameter if passed else use context private_key_file

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -38,9 +38,8 @@ options:
     description:
       - Port number for ssh on the destination host.
       - Prior to Ansible 2.0, the ansible_ssh_port inventory var took precedence over this value.
-      - This parameter defaults to the value of C(ansible_ssh_port) or C(ansible_port),
-        the C(remote_port) config setting or the value from ssh client configuration
-        if none of the former have been set.
+      - This parameter defaults to the value of C(ansible_port), the C(remote_port) config setting
+        or the value from ssh client configuration if none of the former have been set.
     type: int
   mode:
     description:

--- a/tests/unit/plugins/action/fixtures/synchronize/basic/taskvars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic/taskvars_in.json
@@ -44,7 +44,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -74,12 +74,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "el6host", 
+  "ansible_host": "el6host", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -102,7 +102,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -142,7 +142,7 @@
   "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic/taskvars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic/taskvars_out.json
@@ -46,7 +46,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -76,12 +76,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "el6host", 
+  "ansible_host": "el6host", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -106,7 +106,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -147,7 +147,7 @@
   "ansible_python_interpreter": "/usr/bin/python", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_become/task_vars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_become/task_vars_in.json
@@ -44,7 +44,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -74,12 +74,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "el6host", 
+  "ansible_host": "el6host", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -102,7 +102,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -142,7 +142,7 @@
   "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_become/task_vars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_become/task_vars_out.json
@@ -46,7 +46,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -76,12 +76,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "el6host", 
+  "ansible_host": "el6host", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -106,7 +106,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -147,7 +147,7 @@
   "ansible_python_interpreter": "/usr/bin/python", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_become_cli/task_vars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_become_cli/task_vars_in.json
@@ -44,7 +44,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -74,12 +74,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "el6host", 
+  "ansible_host": "el6host", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -102,7 +102,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -142,7 +142,7 @@
   "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_become_cli/task_vars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_become_cli/task_vars_out.json
@@ -46,7 +46,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -76,12 +76,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "el6host", 
+  "ansible_host": "el6host", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -106,7 +106,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__b3ac1e6ebeed06f4be0c1edca3dca34036cf7f57", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -147,7 +147,7 @@
   "ansible_python_interpreter": "/usr/bin/python", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant/task_vars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant/task_vars_in.json
@@ -8,7 +8,7 @@
   ], 
   "ansible_connection": "ssh", 
   "ansible_ssh_common_args": "", 
-  "ansible_ssh_host": "127.0.0.1", 
+  "ansible_host": "127.0.0.1", 
   "inventory_hostname": "default", 
   "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
   "vars": {
@@ -21,7 +21,7 @@
     "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
     "role_names": [], 
     "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-    "ansible_ssh_host": "127.0.0.1", 
+    "ansible_host": "127.0.0.1", 
     "play_hosts": [
       "default"
     ], 
@@ -40,15 +40,15 @@
             "default"
           ]
         }, 
-        "ansible_ssh_port": 2202, 
+        "ansible_port": 2202, 
         "inventory_hostname": "default", 
         "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
         "inventory_hostname_short": "default", 
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__06c4a1b11530cabdf4248804078c1ddacfb88b5e", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-        "ansible_ssh_host": "127.0.0.1", 
-        "ansible_ssh_user": "vagrant", 
+        "ansible_host": "127.0.0.1", 
+        "ansible_user": "vagrant", 
         "group_names": [
           "ungrouped"
         ], 
@@ -73,7 +73,7 @@
       "ungrouped"
     ], 
     "omit": "__omit_place_holder__06c4a1b11530cabdf4248804078c1ddacfb88b5e", 
-    "ansible_ssh_port": 2202, 
+    "ansible_port": 2202, 
     "ansible_version": {
       "major": 2, 
       "full": "2.2.0", 
@@ -81,7 +81,7 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "vagrant"
+    "ansible_user": "vagrant"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
@@ -102,15 +102,15 @@
           "default"
         ]
       }, 
-      "ansible_ssh_port": 2202, 
+      "ansible_port": 2202, 
       "inventory_hostname": "default", 
       "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
       "inventory_hostname_short": "default", 
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__06c4a1b11530cabdf4248804078c1ddacfb88b5e", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-      "ansible_ssh_host": "127.0.0.1", 
-      "ansible_ssh_user": "vagrant", 
+      "ansible_host": "127.0.0.1", 
+      "ansible_user": "vagrant", 
       "group_names": [
         "ungrouped"
       ], 
@@ -148,14 +148,14 @@
       "default"
     ]
   }, 
-  "ansible_ssh_port": 2202, 
+  "ansible_port": 2202, 
   "ansible_host": "127.0.0.1", 
   "ansible_shell_executable": "/bin/sh", 
   "inventory_hostname_short": "default", 
   "omit": "__omit_place_holder__06c4a1b11530cabdf4248804078c1ddacfb88b5e", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "vagrant", 
+  "ansible_user": "vagrant", 
   "role_names": [], 
   "play_hosts": [
     "default"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant/task_vars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant/task_vars_out.json
@@ -8,7 +8,7 @@
   ], 
   "ansible_connection": "ssh", 
   "ansible_ssh_common_args": "", 
-  "ansible_ssh_host": "127.0.0.1", 
+  "ansible_host": "127.0.0.1", 
   "inventory_hostname": "default", 
   "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
   "vars": {
@@ -21,7 +21,7 @@
     "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
     "role_names": [], 
     "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-    "ansible_ssh_host": "127.0.0.1", 
+    "ansible_host": "127.0.0.1", 
     "play_hosts": [
       "default"
     ], 
@@ -42,15 +42,15 @@
             "::1"
           ]
         }, 
-        "ansible_ssh_port": 2202, 
+        "ansible_port": 2202, 
         "inventory_hostname": "default", 
         "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
         "inventory_hostname_short": "default", 
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__06c4a1b11530cabdf4248804078c1ddacfb88b5e", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-        "ansible_ssh_host": "127.0.0.1", 
-        "ansible_ssh_user": "vagrant", 
+        "ansible_host": "127.0.0.1", 
+        "ansible_user": "vagrant", 
         "group_names": [
           "ungrouped"
         ], 
@@ -75,7 +75,7 @@
       "ungrouped"
     ], 
     "omit": "__omit_place_holder__06c4a1b11530cabdf4248804078c1ddacfb88b5e", 
-    "ansible_ssh_port": 2202, 
+    "ansible_port": 2202, 
     "ansible_version": {
       "major": 2, 
       "full": "2.2.0", 
@@ -83,7 +83,7 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "vagrant"
+    "ansible_user": "vagrant"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
@@ -106,15 +106,15 @@
           "::1"
         ]
       }, 
-      "ansible_ssh_port": 2202, 
+      "ansible_port": 2202, 
       "inventory_hostname": "default", 
       "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
       "inventory_hostname_short": "default", 
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__06c4a1b11530cabdf4248804078c1ddacfb88b5e", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-      "ansible_ssh_host": "127.0.0.1", 
-      "ansible_ssh_user": "vagrant", 
+      "ansible_host": "127.0.0.1", 
+      "ansible_user": "vagrant", 
       "group_names": [
         "ungrouped"
       ], 
@@ -152,7 +152,7 @@
       "default"
     ]
   }, 
-  "ansible_ssh_port": 2202, 
+  "ansible_port": 2202, 
   "ansible_host": "127.0.0.1", 
   "ansible_shell_executable": "/bin/sh", 
   "inventory_hostname_short": "default", 
@@ -160,7 +160,7 @@
   "ansible_python_interpreter": "/usr/bin/python", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "vagrant", 
+  "ansible_user": "vagrant", 
   "role_names": [], 
   "play_hosts": [
     "default"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_become_cli/task_vars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_become_cli/task_vars_in.json
@@ -8,7 +8,7 @@
   ], 
   "ansible_connection": "ssh", 
   "ansible_ssh_common_args": "", 
-  "ansible_ssh_host": "127.0.0.1", 
+  "ansible_host": "127.0.0.1", 
   "inventory_hostname": "default", 
   "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
   "vars": {
@@ -21,7 +21,7 @@
     "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
     "role_names": [], 
     "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-    "ansible_ssh_host": "127.0.0.1", 
+    "ansible_host": "127.0.0.1", 
     "play_hosts": [
       "default"
     ], 
@@ -40,15 +40,15 @@
             "default"
           ]
         }, 
-        "ansible_ssh_port": 2202, 
+        "ansible_port": 2202, 
         "inventory_hostname": "default", 
         "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
         "inventory_hostname_short": "default", 
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-        "ansible_ssh_host": "127.0.0.1", 
-        "ansible_ssh_user": "vagrant", 
+        "ansible_host": "127.0.0.1", 
+        "ansible_user": "vagrant", 
         "group_names": [
           "ungrouped"
         ], 
@@ -73,7 +73,7 @@
       "ungrouped"
     ], 
     "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
-    "ansible_ssh_port": 2202, 
+    "ansible_port": 2202, 
     "ansible_version": {
       "major": 2, 
       "full": "2.2.0", 
@@ -81,7 +81,7 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "vagrant"
+    "ansible_user": "vagrant"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
@@ -102,15 +102,15 @@
           "default"
         ]
       }, 
-      "ansible_ssh_port": 2202, 
+      "ansible_port": 2202, 
       "inventory_hostname": "default", 
       "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
       "inventory_hostname_short": "default", 
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-      "ansible_ssh_host": "127.0.0.1", 
-      "ansible_ssh_user": "vagrant", 
+      "ansible_host": "127.0.0.1", 
+      "ansible_user": "vagrant", 
       "group_names": [
         "ungrouped"
       ], 
@@ -148,14 +148,14 @@
       "default"
     ]
   }, 
-  "ansible_ssh_port": 2202, 
+  "ansible_port": 2202, 
   "ansible_host": "127.0.0.1", 
   "ansible_shell_executable": "/bin/sh", 
   "inventory_hostname_short": "default", 
   "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "vagrant", 
+  "ansible_user": "vagrant", 
   "role_names": [], 
   "play_hosts": [
     "default"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_become_cli/task_vars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_become_cli/task_vars_out.json
@@ -8,7 +8,7 @@
   ], 
   "ansible_connection": "ssh", 
   "ansible_ssh_common_args": "", 
-  "ansible_ssh_host": "127.0.0.1", 
+  "ansible_host": "127.0.0.1", 
   "inventory_hostname": "default", 
   "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
   "vars": {
@@ -21,7 +21,7 @@
     "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
     "role_names": [], 
     "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-    "ansible_ssh_host": "127.0.0.1", 
+    "ansible_host": "127.0.0.1", 
     "play_hosts": [
       "default"
     ], 
@@ -42,15 +42,15 @@
             "::1"
           ]
         }, 
-        "ansible_ssh_port": 2202, 
+        "ansible_port": 2202, 
         "inventory_hostname": "default", 
         "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
         "inventory_hostname_short": "default", 
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-        "ansible_ssh_host": "127.0.0.1", 
-        "ansible_ssh_user": "vagrant", 
+        "ansible_host": "127.0.0.1", 
+        "ansible_user": "vagrant", 
         "group_names": [
           "ungrouped"
         ], 
@@ -75,7 +75,7 @@
       "ungrouped"
     ], 
     "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
-    "ansible_ssh_port": 2202, 
+    "ansible_port": 2202, 
     "ansible_version": {
       "major": 2, 
       "full": "2.2.0", 
@@ -83,7 +83,7 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "vagrant"
+    "ansible_user": "vagrant"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
@@ -106,15 +106,15 @@
           "::1"
         ]
       }, 
-      "ansible_ssh_port": 2202, 
+      "ansible_port": 2202, 
       "inventory_hostname": "default", 
       "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
       "inventory_hostname_short": "default", 
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-      "ansible_ssh_host": "127.0.0.1", 
-      "ansible_ssh_user": "vagrant", 
+      "ansible_host": "127.0.0.1", 
+      "ansible_user": "vagrant", 
       "group_names": [
         "ungrouped"
       ], 
@@ -152,7 +152,7 @@
       "default"
     ]
   }, 
-  "ansible_ssh_port": 2202, 
+  "ansible_port": 2202, 
   "ansible_host": "127.0.0.1", 
   "ansible_shell_executable": "/bin/sh", 
   "inventory_hostname_short": "default", 
@@ -160,7 +160,7 @@
   "ansible_python_interpreter": "/usr/bin/python", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "vagrant", 
+  "ansible_user": "vagrant", 
   "role_names": [], 
   "play_hosts": [
     "default"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_sudo/task_vars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_sudo/task_vars_in.json
@@ -8,7 +8,7 @@
   ], 
   "ansible_connection": "ssh", 
   "ansible_ssh_common_args": "", 
-  "ansible_ssh_host": "127.0.0.1", 
+  "ansible_host": "127.0.0.1", 
   "inventory_hostname": "default", 
   "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
   "vars": {
@@ -21,7 +21,7 @@
     "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
     "role_names": [], 
     "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-    "ansible_ssh_host": "127.0.0.1", 
+    "ansible_host": "127.0.0.1", 
     "play_hosts": [
       "default"
     ], 
@@ -40,15 +40,15 @@
             "default"
           ]
         }, 
-        "ansible_ssh_port": 2202, 
+        "ansible_port": 2202, 
         "inventory_hostname": "default", 
         "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
         "inventory_hostname_short": "default", 
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-        "ansible_ssh_host": "127.0.0.1", 
-        "ansible_ssh_user": "vagrant", 
+        "ansible_host": "127.0.0.1", 
+        "ansible_user": "vagrant", 
         "group_names": [
           "ungrouped"
         ], 
@@ -73,7 +73,7 @@
       "ungrouped"
     ], 
     "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
-    "ansible_ssh_port": 2202, 
+    "ansible_port": 2202, 
     "ansible_version": {
       "major": 2, 
       "full": "2.2.0", 
@@ -81,7 +81,7 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "vagrant"
+    "ansible_user": "vagrant"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
@@ -102,15 +102,15 @@
           "default"
         ]
       }, 
-      "ansible_ssh_port": 2202, 
+      "ansible_port": 2202, 
       "inventory_hostname": "default", 
       "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
       "inventory_hostname_short": "default", 
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-      "ansible_ssh_host": "127.0.0.1", 
-      "ansible_ssh_user": "vagrant", 
+      "ansible_host": "127.0.0.1", 
+      "ansible_user": "vagrant", 
       "group_names": [
         "ungrouped"
       ], 
@@ -148,14 +148,14 @@
       "default"
     ]
   }, 
-  "ansible_ssh_port": 2202, 
+  "ansible_port": 2202, 
   "ansible_host": "127.0.0.1", 
   "ansible_shell_executable": "/bin/sh", 
   "inventory_hostname_short": "default", 
   "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "vagrant", 
+  "ansible_user": "vagrant", 
   "role_names": [], 
   "play_hosts": [
     "default"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_sudo/task_vars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_sudo/task_vars_out.json
@@ -8,7 +8,7 @@
   ], 
   "ansible_connection": "ssh", 
   "ansible_ssh_common_args": "", 
-  "ansible_ssh_host": "127.0.0.1", 
+  "ansible_host": "127.0.0.1", 
   "inventory_hostname": "default", 
   "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
   "vars": {
@@ -21,7 +21,7 @@
     "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
     "role_names": [], 
     "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-    "ansible_ssh_host": "127.0.0.1", 
+    "ansible_host": "127.0.0.1", 
     "play_hosts": [
       "default"
     ], 
@@ -42,15 +42,15 @@
             "::1"
           ]
         }, 
-        "ansible_ssh_port": 2202, 
+        "ansible_port": 2202, 
         "inventory_hostname": "default", 
         "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
         "inventory_hostname_short": "default", 
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-        "ansible_ssh_host": "127.0.0.1", 
-        "ansible_ssh_user": "vagrant", 
+        "ansible_host": "127.0.0.1", 
+        "ansible_user": "vagrant", 
         "group_names": [
           "ungrouped"
         ], 
@@ -75,7 +75,7 @@
       "ungrouped"
     ], 
     "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
-    "ansible_ssh_port": 2202, 
+    "ansible_port": 2202, 
     "ansible_version": {
       "major": 2, 
       "full": "2.2.0", 
@@ -83,7 +83,7 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "vagrant"
+    "ansible_user": "vagrant"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
@@ -106,15 +106,15 @@
           "::1"
         ]
       }, 
-      "ansible_ssh_port": 2202, 
+      "ansible_port": 2202, 
       "inventory_hostname": "default", 
       "ansible_ssh_private_key_file": "/home/jtanner/workspace/issues/AP-15905/.vagrant/machines/default/virtualbox/private_key", 
       "inventory_hostname_short": "default", 
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__c360b80aa60ddd99087425dcd3a2094cdd5b8474", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
-      "ansible_ssh_host": "127.0.0.1", 
-      "ansible_ssh_user": "vagrant", 
+      "ansible_host": "127.0.0.1", 
+      "ansible_user": "vagrant", 
       "group_names": [
         "ungrouped"
       ], 
@@ -152,7 +152,7 @@
       "default"
     ]
   }, 
-  "ansible_ssh_port": 2202, 
+  "ansible_port": 2202, 
   "ansible_host": "127.0.0.1", 
   "ansible_shell_executable": "/bin/sh", 
   "inventory_hostname_short": "default", 
@@ -160,7 +160,7 @@
   "ansible_python_interpreter": "/usr/bin/python", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905/.vagrant/provisioners/ansible/inventory", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "vagrant", 
+  "ansible_user": "vagrant", 
   "role_names": [], 
   "play_hosts": [
     "default"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/taskvars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/taskvars_in.json
@@ -44,7 +44,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -74,12 +74,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "el6host", 
+  "ansible_host": "el6host", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -102,7 +102,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -142,7 +142,7 @@
   "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/taskvars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/taskvars_out.json
@@ -46,7 +46,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -76,12 +76,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "el6host", 
+  "ansible_host": "el6host", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -106,7 +106,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__03600813b83569c710bf5cb2a040d6e01da927c6", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -147,7 +147,7 @@
   "ansible_python_interpreter": "/usr/bin/python", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote/task_vars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote/task_vars_in.json
@@ -41,7 +41,7 @@
           "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
           "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
           "environment": [], 
-          "ansible_ssh_user": "root", 
+          "ansible_user": "root", 
           "group_names": [
             "ungrouped"
           ], 
@@ -91,7 +91,7 @@
           "minor": 2, 
           "revision": 0
         }, 
-        "ansible_ssh_user": "root"
+        "ansible_user": "root"
       }
     }, 
     "inventory_hostname_short": "el6host", 
@@ -126,7 +126,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -156,7 +156,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -188,12 +188,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "u1404", 
+  "ansible_host": "u1404", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -218,7 +218,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -248,7 +248,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -284,7 +284,7 @@
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "environment": [], 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_play_hosts": [
           "el6host"
         ], 
@@ -348,7 +348,7 @@
         "minor": 2, 
         "revision": 0
       }, 
-      "ansible_ssh_user": "root"
+      "ansible_user": "root"
     }
   }, 
   "ansible_module_compression": "ZIP_DEFLATED", 
@@ -370,7 +370,7 @@
   "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote/task_vars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote/task_vars_out.json
@@ -41,7 +41,7 @@
           "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
           "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
           "environment": [], 
-          "ansible_ssh_user": "root", 
+          "ansible_user": "root", 
           "group_names": [
             "ungrouped"
           ], 
@@ -91,7 +91,7 @@
           "minor": 2, 
           "revision": 0
         }, 
-        "ansible_ssh_user": "root"
+        "ansible_user": "root"
       }
     }, 
     "inventory_hostname_short": "el6host", 
@@ -128,7 +128,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -160,7 +160,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -192,12 +192,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "u1404", 
+  "ansible_host": "u1404", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -224,7 +224,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -256,7 +256,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -292,7 +292,7 @@
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "environment": [], 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_play_hosts": [
           "el6host"
         ], 
@@ -356,7 +356,7 @@
         "minor": 2, 
         "revision": 0
       }, 
-      "ansible_ssh_user": "root"
+      "ansible_user": "root"
     }
   }, 
   "ansible_module_compression": "ZIP_DEFLATED", 
@@ -378,7 +378,7 @@
   "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_play_context_private_key/task_vars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_play_context_private_key/task_vars_in.json
@@ -41,7 +41,7 @@
           "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
           "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
           "environment": [], 
-          "ansible_ssh_user": "root", 
+          "ansible_user": "root", 
           "group_names": [
             "ungrouped"
           ], 
@@ -91,7 +91,7 @@
           "minor": 2, 
           "revision": 0
         }, 
-        "ansible_ssh_user": "root"
+        "ansible_user": "root"
       }
     }, 
     "inventory_hostname_short": "el6host", 
@@ -126,7 +126,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -156,7 +156,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -188,12 +188,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "u1404", 
+  "ansible_host": "u1404", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -218,7 +218,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -248,7 +248,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -284,7 +284,7 @@
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "environment": [], 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_play_hosts": [
           "el6host"
         ], 
@@ -348,7 +348,7 @@
         "minor": 2, 
         "revision": 0
       }, 
-      "ansible_ssh_user": "root"
+      "ansible_user": "root"
     }
   }, 
   "ansible_module_compression": "ZIP_DEFLATED", 
@@ -370,7 +370,7 @@
   "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_play_context_private_key/task_vars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_play_context_private_key/task_vars_out.json
@@ -41,7 +41,7 @@
           "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
           "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
           "environment": [], 
-          "ansible_ssh_user": "root", 
+          "ansible_user": "root", 
           "group_names": [
             "ungrouped"
           ], 
@@ -91,7 +91,7 @@
           "minor": 2, 
           "revision": 0
         }, 
-        "ansible_ssh_user": "root"
+        "ansible_user": "root"
       }
     }, 
     "inventory_hostname_short": "el6host", 
@@ -128,7 +128,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -160,7 +160,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -192,12 +192,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "u1404", 
+  "ansible_host": "u1404", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -224,7 +224,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -256,7 +256,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -292,7 +292,7 @@
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "environment": [], 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_play_hosts": [
           "el6host"
         ], 
@@ -356,7 +356,7 @@
         "minor": 2, 
         "revision": 0
       }, 
-      "ansible_ssh_user": "root"
+      "ansible_user": "root"
     }
   }, 
   "ansible_module_compression": "ZIP_DEFLATED", 
@@ -378,7 +378,7 @@
   "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_su/task_vars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_su/task_vars_in.json
@@ -41,7 +41,7 @@
           "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
           "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
           "environment": [], 
-          "ansible_ssh_user": "root", 
+          "ansible_user": "root", 
           "group_names": [
             "ungrouped"
           ], 
@@ -91,7 +91,7 @@
           "minor": 2, 
           "revision": 0
         }, 
-        "ansible_ssh_user": "root"
+        "ansible_user": "root"
       }
     }, 
     "inventory_hostname_short": "el6host", 
@@ -126,7 +126,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -156,7 +156,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -188,12 +188,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "u1404", 
+  "ansible_host": "u1404", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -218,7 +218,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -248,7 +248,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -284,7 +284,7 @@
         "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "environment": [], 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_play_hosts": [
           "el6host"
         ], 
@@ -348,7 +348,7 @@
         "minor": 2, 
         "revision": 0
       }, 
-      "ansible_ssh_user": "root"
+      "ansible_user": "root"
     }
   }, 
   "ansible_module_compression": "ZIP_DEFLATED", 
@@ -370,7 +370,7 @@
   "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_su/task_vars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_su/task_vars_out.json
@@ -41,7 +41,7 @@
           "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
           "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
           "environment": [], 
-          "ansible_ssh_user": "root", 
+          "ansible_user": "root", 
           "group_names": [
             "ungrouped"
           ], 
@@ -91,7 +91,7 @@
           "minor": 2, 
           "revision": 0
         }, 
-        "ansible_ssh_user": "root"
+        "ansible_user": "root"
       }
     }, 
     "inventory_hostname_short": "el6host", 
@@ -128,7 +128,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -160,7 +160,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -192,12 +192,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "u1404", 
+  "ansible_host": "u1404", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -224,7 +224,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -256,7 +256,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -292,7 +292,7 @@
         "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "environment": [], 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_play_hosts": [
           "el6host"
         ], 
@@ -356,7 +356,7 @@
         "minor": 2, 
         "revision": 0
       }, 
-      "ansible_ssh_user": "root"
+      "ansible_user": "root"
     }
   }, 
   "ansible_module_compression": "ZIP_DEFLATED", 
@@ -378,7 +378,7 @@
   "omit": "__omit_place_holder__32a8706cee222390e0d92197fb49cc967bfafb57", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_with_private_key/task_vars_in.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_with_private_key/task_vars_in.json
@@ -41,7 +41,7 @@
           "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
           "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
           "environment": [], 
-          "ansible_ssh_user": "root", 
+          "ansible_user": "root", 
           "group_names": [
             "ungrouped"
           ], 
@@ -91,7 +91,7 @@
           "minor": 2, 
           "revision": 0
         }, 
-        "ansible_ssh_user": "root"
+        "ansible_user": "root"
       }
     }, 
     "inventory_hostname_short": "el6host", 
@@ -126,7 +126,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -156,7 +156,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -188,12 +188,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "u1404", 
+  "ansible_host": "u1404", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -218,7 +218,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -248,7 +248,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -284,7 +284,7 @@
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "environment": [], 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_play_hosts": [
           "el6host"
         ], 
@@ -348,7 +348,7 @@
         "minor": 2, 
         "revision": 0
       }, 
-      "ansible_ssh_user": "root"
+      "ansible_user": "root"
     }
   }, 
   "ansible_module_compression": "ZIP_DEFLATED", 
@@ -370,7 +370,7 @@
   "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"

--- a/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_with_private_key/task_vars_out.json
+++ b/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_with_private_key/task_vars_out.json
@@ -41,7 +41,7 @@
           "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
           "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
           "environment": [], 
-          "ansible_ssh_user": "root", 
+          "ansible_user": "root", 
           "group_names": [
             "ungrouped"
           ], 
@@ -91,7 +91,7 @@
           "minor": 2, 
           "revision": 0
         }, 
-        "ansible_ssh_user": "root"
+        "ansible_user": "root"
       }
     }, 
     "inventory_hostname_short": "el6host", 
@@ -128,7 +128,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -160,7 +160,7 @@
         "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_check_mode": false, 
         "ansible_version": {
           "major": 2, 
@@ -192,12 +192,12 @@
       "minor": 2, 
       "revision": 0
     }, 
-    "ansible_ssh_user": "root"
+    "ansible_user": "root"
   }, 
   "ansible_accelerate_port": 5099, 
   "roledir": null, 
   "ansible_ssh_extra_args": "", 
-  "ansible_ssh_host": "u1404", 
+  "ansible_host": "u1404", 
   "ansible_current_hosts": [
     "el6host"
   ], 
@@ -224,7 +224,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -256,7 +256,7 @@
       "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
       "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
       "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
-      "ansible_ssh_user": "root", 
+      "ansible_user": "root", 
       "ansible_check_mode": false, 
       "ansible_version": {
         "major": 2, 
@@ -292,7 +292,7 @@
         "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
         "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
         "environment": [], 
-        "ansible_ssh_user": "root", 
+        "ansible_user": "root", 
         "ansible_play_hosts": [
           "el6host"
         ], 
@@ -356,7 +356,7 @@
         "minor": 2, 
         "revision": 0
       }, 
-      "ansible_ssh_user": "root"
+      "ansible_user": "root"
     }
   }, 
   "ansible_module_compression": "ZIP_DEFLATED", 
@@ -378,7 +378,7 @@
   "omit": "__omit_place_holder__2433ce0463ffd13b68850ce9cdd98a1cde088e22", 
   "inventory_dir": "/home/jtanner/workspace/issues/AP-15905", 
   "playbook_dir": "/home/jtanner/workspace/issues/AP-15905", 
-  "ansible_ssh_user": "root", 
+  "ansible_user": "root", 
   "role_names": [], 
   "play_hosts": [
     "el6host"


### PR DESCRIPTION
##### SUMMARY

Documentation doesn't refer to `ansible_ssh_user` anymore, not even as a deprecated option: https://docs.ansible.com/ansible/2.9/user_guide/intro_inventory.html, although `synchronize`'s action plugin and unit tests still use it in place of (or mixed with) `ansible_user`.

Fixes #60 

This pull request turns all *ansible_ssh_user*, *ansible_ssh_port* and *ansible_ssh_host* into ***ansible_user***,  ***ansible_port*** and ***ansible_host***.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

synchronize