### PR TITLE
allow-firewalld-take-multiple-input

### DIFF
--- a/changelogs/fragments/firewalld_multiple_input_values.yml
+++ b/changelogs/fragments/firewalld_multiple_input_values.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - firewalld - Allow multiple values input as a list or coma separated string
+    for input types source, service, port, icmp_block, interface, rich_rule.


### PR DESCRIPTION
The currentl firewalld module does not take multiple values such as
`source` or `interface`, etc..

There are many cases that we need to pass multi volume to the module
rather than flatening the input so I implement it in this PR.

This change is backward compatible, that is the behaviour wont change after this change,
an existing user uses single value will work as is.

##### SUMMARY

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
firewalld

##### ADDITIONAL INFORMATION

