### PR TITLE
fix a race condition by locking fstab with ansible's FileLock

### DIFF
--- a/changelogs/fragments/161-fix-115_race_condition_in_mount_module.yml
+++ b/changelogs/fragments/161-fix-115_race_condition_in_mount_module.yml
@@ -1,0 +1,6 @@
+---
+bugfixes:
+  - mount - fix a race condition that might result in unknown/unexpected fstab
+    state when running the module on several inventory hostnames adressing the
+    same host. Lock it with ansible.module_utils.common.file.FileLock.lock_file()
+    (https://github.com/ansible-collections/ansible.posix/issues/115).

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -766,7 +766,7 @@ def main():
 
     lock_timeout = 2
     lock_tempdir = '/tmp'
-    lock_message = 'another instance of the module holds the %s lock' % os.path.basename(args['fstab'])
+    lock_message = 'another instance of the module holds the %s lock: timeout (%s)'
 
     _fstab = FileLock()
     try:
@@ -872,8 +872,8 @@ def main():
             else:
                 module.fail_json(msg='Unexpected position reached')
 
-    except LockTimeout:
-        module.fail_json(msg=lock_message)
+    except LockTimeout as e:
+        module.fail_json(msg=lock_message % (os.path.basename(args['fstab']), to_native(e)))
 
     # If the managed node is Solaris, convert the boot value type to Boolean
     #  to match the type of return value with the module argument.


### PR DESCRIPTION
##### SUMMARY

When running the `mount` module with either `state=absent`, `state=present` or `state=mounted` on several inventory hostnames addressing the same host, each instance of the module modifies system file `/etc/fstab` on the host in a way that may result in unknown/undefined/unexpected states of the file (fstab).

Fixes #115 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

mount

##### ADDITIONAL INFORMATION

See the referenced issue report for rationale and usecase.

In my tests, not only the `mounted` state might cause a failure when trying to mount a mountpoint that is not recorded in fstab, but also the `absent` state may leave records referencing mountpoints (directories) removed by the module, without failure of the module itself, and leading system to fail to reboot.

Here is my test playbook:
```yaml
---
- name: test race condition with the 'mount' module
  hosts: race
  become: yes
  gather_facts: no
  tasks:
    - name: Unmount filesystem
      mount:
        path: "/tmp/mountpoints/{{ inventory_hostname.split('.')[1] }}"
        src: "/dev/mapper/vg0-test_{{ inventory_hostname.split('.')[1] }}"
        fstype: ext4
        state: absent
      retries: 1

    - name: Get results after removal
      command:
        cmd: "grep /tmp/mountpoints/{{ inventory_hostname.split('.')[1] }} /etc/fstab"
      register: grep
      changed_when: false
      failed_when: grep.rc == 0
      ignore_errors: yes

    - name: Copy file for debugging
      copy:
        src: /etc/fstab
        dest: /tmp/debug
        mode: u=rw,go=r
        owner: ksys
        group: ksys
        remote_src: yes
      run_once: yes

    - name: Restore backup
      copy:
        src: /tmp/fstab
        dest: /etc/fstab
        mode: u=rw,go=r
        owner: root
        group: root
        remote_src: yes
      run_once: yes

    - name: Mount FS over directory
      mount:
        path: "/tmp/mountpoints/{{ inventory_hostname.split('.')[1] }}"
        src: "/dev/mapper/vg0-test_{{ inventory_hostname.split('.')[1] }}"
        fstype: ext4
        state: mounted

    - name: Get results after mount
      command:
        cmd: "grep /tmp/mountpoints/{{ inventory_hostname.split('.')[1] }} /etc/fstab"
      changed_when: false
      ignore_errors: yes
```

When ran against 24 inventory hosts (that are only one VM) in parallel, 100 consecutive times for each test, with tests by:
- the main/current version of the module, varying `forks` value in ansible.cfg (1, **5**, 7, 10)
- the pull-request's version of the module, varying its lock_timeout value (0, 1, 5, 10) (this is the delay for the module to acquire the lock, after what it fails) and `forks` (**5**, 10)

it appears that:
- race increases with `forks` value (not a surprise in this case)
- setting `lock_timeout` to 0 also increases the errors rate, showing that the lock is the point
- setting `lock_timeout` to a higher value solves the issue