### PR TITLE
ansible.posix.mount: add absent_from_fstab option

### DIFF
--- a/changelogs/fragments/166_mount_absent_fstab.yml
+++ b/changelogs/fragments/166_mount_absent_fstab.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- mount - Add absent_from_fstab state
+  - mount - Add ``absent_from_fstab`` state (https://github.com/ansible-collections/ansible.posix/pull/166).

--- a/changelogs/fragments/166_mount_absent_fstab.yml
+++ b/changelogs/fragments/166_mount_absent_fstab.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- mount - Add absent_from_fstab state

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -78,9 +78,12 @@ options:
         if I(opts) is set, and the remount command fails, the module will
         error to prevent unexpected mount changes.  Try using C(mounted)
         instead to work around this issue.
+      - C(absent_from_fstab) specifies that the device mount's entry will be
+        removed from I(fstab). This option does not unmount it or delete the
+        mountpoint.
     type: str
     required: true
-    choices: [ absent, mounted, present, unmounted, remounted ]
+    choices: [ absent, absent_from_fstab, mounted, present, unmounted, remounted ]
   fstab:
     description:
       - File to use instead of C(/etc/fstab).
@@ -651,7 +654,7 @@ def main():
             passno=dict(type='str', no_log=False),
             src=dict(type='path'),
             backup=dict(type='bool', default=False),
-            state=dict(type='str', required=True, choices=['absent', 'mounted', 'present', 'unmounted', 'remounted']),
+            state=dict(type='str', required=True, choices=['absent', 'absent_from_fstab', 'mounted', 'present', 'unmounted', 'remounted']),
         ),
         supports_check_mode=True,
         required_if=(
@@ -734,7 +737,9 @@ def main():
     name = module.params['path']
     changed = False
 
-    if state == 'absent':
+    if state == 'absent_from_fstab':
+        name, changed = unset_mount(module, args)
+    elif state == 'absent':
         name, changed = unset_mount(module, args)
 
         if changed and not module.check_mode:


### PR DESCRIPTION
##### SUMMARY
Add absent_from_fstab option to remove the entry from fstab, but not unmount or delete the folder. Ideally this would have been the behavior of absent (as to mirror the behavior of present), but for backward compatibility I added a new verbose state

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
mount

##### ADDITIONAL INFORMATION
Sometimes you may not want to delete the mountpoint (e.g. if it is not currently mounted and data is in the directory, the current behavior will simply error).