### PR TITLE
synchronize: add delay_updates option

### DIFF
--- a/changelogs/fragments/167-synchronize-add_delay_option.yml
+++ b/changelogs/fragments/167-synchronize-add_delay_option.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - synchronize - add ``delay_updates`` option (https://github.com/ansible-collections/ansible.posix/issues/157).

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -184,6 +184,7 @@ options:
         at which time all the files are renamed into place in rapid succession.
     type: bool
     default: yes
+    version_added: '1.3.0'
 
 notes:
    - rsync must be installed on both the local and remote host.

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -462,9 +462,6 @@ def main():
         rsync = module.get_bin_path(rsync, required=True)
 
     cmd = [rsync]
-    if delay_updates:
-        cmd.append('--delay_updates')
-        cmd.append('-F')
     _sshpass_pipe = None
     if rsync_password:
         try:
@@ -475,6 +472,9 @@ def main():
             )
         _sshpass_pipe = os.pipe()
         cmd = ['sshpass', '-d' + to_native(_sshpass_pipe[0], errors='surrogate_or_strict')] + cmd
+    if delay_updates:
+        cmd.append('--delay_updates')
+        cmd.append('-F')
     if compress:
         cmd.append('--compress')
     if rsync_timeout:


### PR DESCRIPTION
##### SUMMARY
Fixes https://github.com/ansible-collections/ansible.posix/issues/157

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
synchronize

##### ADDITIONAL INFORMATION
This does not disable the `delay-updates` by default, so current behaviour will not be changed, but adds an option which can be set to false and disable `delay-updates`.