### PR TITLE
Append line-separator to the end of command line

### DIFF
--- a/changelogs/fragments/169_add_lineseparator_to_command.yml
+++ b/changelogs/fragments/169_add_lineseparator_to_command.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - at - append line-separator to the end of the ``command`` (https://github.com/ansible-collections/ansible.posix/issues/169).

--- a/plugins/modules/at.py
+++ b/plugins/modules/at.py
@@ -129,7 +129,7 @@ def get_matching_jobs(module, at_cmd, script_file):
 def create_tempfile(command):
     filed, script_file = tempfile.mkstemp(prefix='at')
     fileh = os.fdopen(filed, 'w')
-    fileh.write(command)
+    fileh.write(command + os.linesep)
     fileh.close()
     return script_file
 


### PR DESCRIPTION
##### SUMMARY

Fixes #169

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ansible.posix.at

##### ADDITIONAL INFORMATION
This PR addresses the issue #169. In RHEL8 environment, the command line specified by the `command` parameter will not execute because line-saparater is not inserted at the end of command line.
For the RHEL7 environment(or others), an extra line separator will be insterted at the end of the command line, but I think it is unaffected for `at` command behavior.

