### PR TITLE
Add ignore file for sanity test on devel version 2.12

### DIFF
--- a/changelogs/fragments/sanity_test_ignore_file.yml
+++ b/changelogs/fragments/sanity_test_ignore_file.yml
@@ -1,0 +1,2 @@
+trivial:
+- Add sanity test ignore file for ansible version 2.12

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,0 +1,8 @@
+plugins/modules/synchronize.py pylint:blacklisted-name
+plugins/modules/synchronize.py use-argspec-type-path
+plugins/modules/synchronize.py validate-modules:doc-default-does-not-match-spec
+plugins/modules/synchronize.py validate-modules:nonexistent-parameter-documented
+plugins/modules/synchronize.py validate-modules:parameter-type-not-in-doc
+plugins/modules/synchronize.py validate-modules:undocumented-parameter
+tests/utils/shippable/check_matrix.py replace-urlopen
+tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY
Add ignore file(ignore-2.12.txt) to cover sanity test on the current devel version 2.12

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ansible.posix
- ansible-test

##### ADDITIONAL INFORMATION
This fix will avoid the following errors during sanity test:

```
ERROR: Found 8 validate-modules issue(s) which need to be resolved:
ERROR: plugins/modules/synchronize.py:0:0: doc-default-does-not-match-spec: Argument '_local_rsync_path' in argument_spec defines default as ('rsync') but documentation defines default as (None)
ERROR: plugins/modules/synchronize.py:0:0: doc-default-does-not-match-spec: Argument '_substitute_controller' in argument_spec defines default as (False) but documentation defines default as (None)
ERROR: plugins/modules/synchronize.py:0:0: nonexistent-parameter-documented: Argument 'use_ssh_args' is listed in DOCUMENTATION.options, but not accepted by the module argument_spec
ERROR: plugins/modules/synchronize.py:0:0: parameter-type-not-in-doc: Argument 'ssh_args' in argument_spec defines type as 'str' but documentation doesn't define type
ERROR: plugins/modules/synchronize.py:0:0: undocumented-parameter: Argument '_local_rsync_password' is listed in the argument_spec, but not documented in the module documentation
ERROR: plugins/modules/synchronize.py:0:0: undocumented-parameter: Argument '_local_rsync_path' is listed in the argument_spec, but not documented in the module documentation
ERROR: plugins/modules/synchronize.py:0:0: undocumented-parameter: Argument '_substitute_controller' is listed in the argument_spec, but not documented in the module documentation
ERROR: plugins/modules/synchronize.py:0:0: undocumented-parameter: Argument 'ssh_args' is listed in the argument_spec, but not documented in the module documentation
```