### PR TITLE
synchronize: fix to honor become_user when become_method sudo

### DIFF
--- a/changelogs/fragments/187-fix-synchronize-become-user.yml
+++ b/changelogs/fragments/187-fix-synchronize-become-user.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - synchronize - use become_user when invoking rsync on remote with sudo
+    (https://github.com/ansible-collections/ansible.posix/issues/186).

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -371,7 +371,10 @@ class ActionModule(ActionBase):
                 # If no rsync_path is set, become was originally set, and dest is
                 # remote then add privilege escalation here.
                 if self._play_context.become_method == 'sudo':
-                    rsync_path = 'sudo rsync'
+                    if self._play_context.become_user:
+                        rsync_path = 'sudo -u %s rsync' % self._play_context.become_user
+                    else:
+                        rsync_path = 'sudo rsync'
                 # TODO: have to add in the rest of the become methods here
 
             # We cannot use privilege escalation on the machine running the

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_become/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_become/meta.yaml
@@ -25,7 +25,8 @@ asserts:
     - "self.execute_called"
     - "self.final_module_args['_local_rsync_path'] == 'rsync'"
     # this is a crucial aspect of this scenario ...
-    - "self.final_module_args['rsync_path'] == 'sudo rsync'"
+    # note: become_user None -> root
+    - "self.final_module_args['rsync_path'] == 'sudo -u root rsync'"
     - "self.final_module_args['src'] == '/tmp/deleteme'"
     - "self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'"
     - "self.task.become == True"

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_become_cli/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_become_cli/meta.yaml
@@ -25,7 +25,8 @@ asserts:
     - "self.execute_called"
     - "self.final_module_args['_local_rsync_path'] == 'rsync'"
     # this is a crucial aspect of this scenario ...
-    - "self.final_module_args['rsync_path'] == 'sudo rsync'"
+    # note: become_user None -> root
+    - "self.final_module_args['rsync_path'] == 'sudo -u root rsync'"
     - "self.final_module_args['src'] == '/tmp/deleteme'"
     - "self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'"
     - "self.task.become == None"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When `become_method` is sudo, the `synchronize` module ignores `become_user`, always running as root.  This means one cannot create files as a target user, when they need to get in via a third user and can only `sudo` via that one.  In my case, I'm connecting via a special provisioning user that has sudo privs, but I need to create the files as the `become_user`.  I'm using it to deposit skeleton files, and there should be no reason to run another task with `chown`; after all, the documentation already describes the desired behavior:

>  The user and permissions for the synchronize `dest` are those of the `remote_user` on the destination host or the `become_user` if `become=yes` is active.

This patch takes the running `become_user` (if it's not `None`) and adds it to the `sudo` command with the `-u` command line option, so the file gets created correctly.  I have tested this and it works.

Other `become_method`s are ignored, but they already were anyways (the code already has a TODO to add other methods, which we don't attempt in this patch)

Fixes #186

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
synchronize

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
See reproduction in #186.

This appears to have been in place since ansible/ansible@811a906332eed12e9d3d976032341a6912b56247
