### PR TITLE
Acl fix performance

### DIFF
--- a/changelogs/fragments/197-acl-fix-performance.yml
+++ b/changelogs/fragments/197-acl-fix-performance.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - "acl - Fix acl module performance (200~https://github.com/ansible-collections/ansible.posix/pull/197)."
+  - acl - Fix module performance (https://github.com/ansible-collections/ansible.posix/pull/197).

--- a/changelogs/fragments/197-acl-fix-performance.yml
+++ b/changelogs/fragments/197-acl-fix-performance.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "acl - Fix acl module performance (200~https://github.com/ansible-collections/ansible.posix/pull/197)."

--- a/plugins/modules/acl.py
+++ b/plugins/modules/acl.py
@@ -280,30 +280,6 @@ def acl_changed(module, cmd, check_rc=True):
                 # left, there is no need to call select() again.
                 break
 
-#            proc.stdout.close()
-#            proc.stderr.close()
-#            selector.close()
-
-
-#        while True:
-#            output = proc.stdout.readline()
-#            if output == '' and proc.poll() is not None:
-#                break
-#            if _acl_module._acl_changed:
-#                continue
-#            lines = []
-#            for l in output.splitlines():
-#                    lines.append(l.strip())
-#            for line in lines:
-#                if not line.endswith(b'*,*'):
-#                    proc.terminate()
-#                    while True:
-#                        output = proc.stdout.readline()
-#                        if output == '' and proc.poll() is not None:
-#                            break
-#                    proc.returncode=0
-#                    _acl_module._acl_changed=True
-
     try:
         (rc, out, err) = module.run_command(
             cmd, check_rc=check_rc,

--- a/plugins/modules/acl.py
+++ b/plugins/modules/acl.py
@@ -255,8 +255,8 @@ def acl_changed(module, cmd, check_rc=True):
                     selector.unregister(key.fileobj)
                 if key.fileobj == proc.stdout:
                     stdout = b_chunk
-            if _acl_module._acl_changed:
-                continue
+                if _acl_module._acl_changed:
+                    continue
             lines = []
             for l in stdout.splitlines():
                 lines.append(l.strip())


### PR DESCRIPTION
##### SUMMARY
This PR fix the acl module performance problem.



##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME
acl
##### ADDITIONAL INFORMATION
When you have more than 7 million files and you have to apply recursive acl, the ansible acl module uses tens of GB of memory.

This is due to the acl module, first try to "apply" acls with the "--test" parameter and analyze the output for any files that change, then apply the setfacl command, and in the last step, run another getfacl command to get the resulting acls, but when you use the recursive option, it makes no sense to get the resulting acls.

With this PR I try to improve performance by making those changes:

First, when you run setfacl with --test, I don't want to get the standard output of the command, the module does not use it, I just want to know if there are any files that change, once I found a file that changes, I terminate the command and do not store the stdout output.
In the last step if I am using the recursive option, I don't want to know the resulting acl, the output only makes sense if there is only one file, not for the recursive one.

With those changes it reduces the memory usage to nothing, before the changes, sometimes, applying it to a file system with more than 7 million files, it used more than 20GB of memory.
It also reduces the execution time, when there is no file that changes, the first step takes the same time, but if there are files that change, the first step is shortened and the last step is not executed.

Command with --check before this PR it also uses gigabytes of ram and the output only shows acls, don't show which file has what acls, so it has no possible use.
```
(venv) alfons@alfonso-escribano ~/dev-ansible $ time ansible test-host -m acl -a 'path="/path/with/files" entity="test" etype="user" permissions="rX"  recursive=true  state="present"' -C 

test-host | CHANGED => {
    "acl": [
        "user::rwx", 
(....)
(....)
(....)

        "default:other::---", 
], 
    "changed": true, 
    "msg": "user:test:rX is present recursively"
}

real    5m0,547s
user    2m37,924s
sys     0m13,495s

```
Command with --check after this PR:
```
(venv) alfons@alfonso-escribano ~/dev-ansible $ time ansible test-host -m acl -a 'path="/path/with/files" entity="test" etype="user" permissions="rX"  recursive=true  state="present"' -C 
 [WARNING]: Not showing resulting acls in the recursive mode

test-host | CHANGED => {
    "acl": [], 
    "changed": true, 
    "msg": "user:test:rX is present recursively"
}

real    0m3,165s
user    0m1,514s
sys     0m0,192s

```