### PR TITLE
firewalld: Ensure idempotency

### DIFF
--- a/changelogs/fragments/179_firewalld.yml
+++ b/changelogs/fragments/179_firewalld.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- firewalld - ensure idempotency with firewalld 0.9.3 (https://github.com/ansible-collections/ansible.posix/issues/179).

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -393,26 +393,14 @@ class PortTransaction(FirewallTransaction):
         )
 
     def get_enabled_immediate(self, port, protocol, timeout):
-        port_proto = [port, protocol]
         if self.fw_offline:
-            fw_zone, fw_settings = self.get_fw_zone_settings()
-            ports_list = fw_settings.getPorts()
-        else:
-            ports_list = self.fw.getPorts(self.zone)
-
-        if port_proto in ports_list:
-            return True
-        else:
-            return False
+            dummy, fw_settings = self.get_fw_zone_settings()
+            return fw_settings.queryPort(port=port, protocol=protocol)
+        return self.fw.queryPort(zone=self.zone, port=port, protocol=protocol)
 
     def get_enabled_permanent(self, port, protocol, timeout):
-        port_proto = (port, protocol)
-        fw_zone, fw_settings = self.get_fw_zone_settings()
-
-        if port_proto in fw_settings.getPorts():
-            return True
-        else:
-            return False
+        dummy, fw_settings = self.get_fw_zone_settings()
+        return fw_settings.queryPort(port=port, protocol=protocol)
 
     def set_enabled_immediate(self, port, protocol, timeout):
         self.fw.addPort(self.zone, port, protocol, timeout)
@@ -715,26 +703,14 @@ class ForwardPortTransaction(FirewallTransaction):
         )
 
     def get_enabled_immediate(self, port, proto, toport, toaddr, timeout):
-        forward_port = [port, proto, toport, toaddr]
         if self.fw_offline:
-            fw_zone, fw_settings = self.get_fw_zone_settings()
-            forward_list = fw_settings.getForwardPorts()
-        else:
-            forward_list = self.fw.getForwardPorts(self.zone)
-
-        if forward_port in forward_list:
-            return True
-        else:
-            return False
+            dummy, fw_settings = self.get_fw_zone_settings()
+            return fw_settings.queryForwardPort(port=port, protocol=proto, to_port=toport, to_addr=toaddr)
+        return self.fw.queryForwardPort(port=port, protocol=proto, to_port=toport, to_addr=toaddr)
 
     def get_enabled_permanent(self, port, proto, toport, toaddr, timeout):
-        forward_port = (port, proto, toport, toaddr)
-        fw_zone, fw_settings = self.get_fw_zone_settings()
-
-        if forward_port in fw_settings.getForwardPorts():
-            return True
-        else:
-            return False
+        dummy, fw_settings = self.get_fw_zone_settings()
+        return fw_settings.queryForwardPort(port=port, protocol=proto, to_port=toport, to_addr=toaddr)
 
     def set_enabled_immediate(self, port, proto, toport, toaddr, timeout):
         self.fw.addForwardPort(self.zone, port, proto, toport, toaddr, timeout)

--- a/tests/integration/targets/firewalld/tasks/main.yml
+++ b/tests/integration/targets/firewalld/tasks/main.yml
@@ -1,20 +1,6 @@
 # Test playbook for the firewalld module
 # (c) 2017, Adam Miller <admiller@redhat.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: Run firewalld tests
   block:

--- a/tests/integration/targets/firewalld/tasks/port_forward_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/port_forward_test_cases.yml
@@ -1,20 +1,6 @@
 # Test playbook for the firewalld module - port operations
 # (c) 2017, Adam Miller <admiller@redhat.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: firewalld port forward test permanent enabled
   firewalld:

--- a/tests/integration/targets/firewalld/tasks/port_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/port_test_cases.yml
@@ -1,20 +1,63 @@
 # Test playbook for the firewalld module - port operations
 # (c) 2017, Adam Miller <admiller@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+- name: firewalld port range test permanent enabled
+  firewalld:
+    port: 5500-6950/tcp
+    permanent: true
+    state: enabled
+  register: result
+
+- name: assert firewalld port range test permanent enabled worked
+  assert:
+    that:
+    - result is changed
+
+- name: firewalld port range test permanent enabled rerun (verify not changed)
+  firewalld:
+    port: 5500-6950/tcp
+    permanent: true
+    state: enabled
+  register: result
+
+- name: assert firewalld port range test permanent enabled rerun worked (verify not changed)
+  assert:
+    that:
+    - result is not changed
+
+- name: firewalld port test permanent enabled
+  firewalld:
+    port: 6900/tcp
+    permanent: true
+    state: enabled
+  register: result
+
+- name: assert firewalld port test permanent enabled worked
+  assert:
+    that:
+    - result is changed
+
+- name: firewalld port test permanent enabled
+  firewalld:
+    port: 6900/tcp
+    permanent: true
+    state: enabled
+  register: result
+
+- name: assert firewalld port test permanent enabled worked
+  assert:
+    that:
+    - result is not changed
+
+- name: firewalld port test disabled
+  firewalld:
+    port: "{{ item }}"
+    permanent: true
+    state: disabled
+  loop:
+    - 6900/tcp
+    - 5500-6950/tcp
 
 - name: firewalld port test permanent enabled
   firewalld:

--- a/tests/integration/targets/firewalld/tasks/run_all_tests.yml
+++ b/tests/integration/targets/firewalld/tasks/run_all_tests.yml
@@ -1,20 +1,6 @@
 # Test playbook for the firewalld module
 # (c) 2017, Adam Miller <admiller@redhat.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: Ensure /run/firewalld exists
   file:
@@ -28,8 +14,6 @@
 
 # firewalld port operation test cases
 - include_tasks: port_test_cases.yml
-  # Skipping on CentOS 8 due to https://github.com/ansible/ansible/issues/64750
-  when: not (ansible_facts.distribution == "CentOS" and ansible_distribution_major_version is version('8', '=='))
 
 # firewalld source operation test cases
 - import_tasks: source_test_cases.yml


### PR DESCRIPTION
##### SUMMARY

Use APIs like ``query*`` instead of ``get*``.

Fixes: #179

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/firewalld.py
tests/integration/targets/firewalld/tasks/main.yml
tests/integration/targets/firewalld/tasks/port_forward_test_cases.yml
tests/integration/targets/firewalld/tasks/port_test_cases.yml
tests/integration/targets/firewalld/tasks/run_all_tests.yml
