### PR TITLE
firewalld: Specify unit for timeout

### DIFF
--- a/changelogs/fragments/193_firewalld.yml
+++ b/changelogs/fragments/193_firewalld.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- firewalld - specify unit for ``timeout`` parameter in docs (https://github.com/ansible-collections/ansible.posix/issues/193).

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -99,7 +99,7 @@ options:
     choices: [ absent, disabled, enabled, present ]
   timeout:
     description:
-      - The amount of time the rule should be in effect for when non-permanent.
+      - The amount of time in seconds the rule should be in effect for when non-permanent.
     type: int
     default: 0
   masquerade:


### PR DESCRIPTION
##### SUMMARY

Timeout parameter takes value which is specified in seconds.

Fixes: #193

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/firewalld.py
