### PR TITLE
synchronize: fix misc typo

### DIFF
--- a/changelogs/fragments/175_synchronize.yml
+++ b/changelogs/fragments/175_synchronize.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- synchronize - fix typo in ``delete`` parameter (https://github.com/ansible-collections/ansible.posix/issues/175).

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -75,7 +75,7 @@ options:
     description:
       - Delete files in C(dest) that don't exist (after transfer, not before) in the C(src) path.
       - This option requires C(recursive=yes).
-      - This option ignores excluded files and behaves like the rsync opt --delete-excluded.
+      - This option ignores excluded files and behaves like the rsync opt --delete-after.
     type: bool
     default: no
   dirs:

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -73,9 +73,9 @@ options:
     default: no
   delete:
     description:
-      - Delete files in C(dest) that don't exist (after transfer, not before) in the C(src) path.
-      - This option requires C(recursive=yes).
-      - This option ignores excluded files and behaves like the rsync opt --delete-after.
+      - Delete files in I(dest) that do not exist (after transfer, not before) in the I(src) path.
+      - This option requires I(recursive=yes).
+      - This option ignores excluded files and behaves like the rsync opt C(--delete-after).
     type: bool
     default: no
   dirs:


### PR DESCRIPTION
##### SUMMARY

Docs should read ``--delete-after`` instead of ``--delete-excluded``.

Fixes: #175

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/synchronize.py
