### PR TITLE
Modify boot option handling on BSD systems

### DIFF
--- a/changelogs/fragments/203_boot_opt_for_bsd.yml
+++ b/changelogs/fragments/203_boot_opt_for_bsd.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - mount - Change behavior of ``boot`` option to set ``noauto`` on BSD nodes
+    (https://github.com/ansible-collections/ansible.posix/issues/28).

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -96,7 +96,10 @@ options:
       - Only applies to Solaris and Linux systems.
       - For Solaris systems, C(true) will set C(yes) as the value of mount at boot
         in I(/etc/vfstab).
-      - For Linux systems, C(true) will add C(noauto) to mount options in I(/etc/fstab).
+      - For Linux, FreeBSD, NetBSD and OpenBSD systems, C(false) will add C(noauto)
+        to mount options in I(/etc/fstab).
+      - To avoid mount option conflicts, if C(noauto) specified in C(opts),
+        mount module will ignore C(boot).
     type: bool
     default: yes
   backup:
@@ -722,10 +725,10 @@ def main():
     for key in ('src', 'fstype', 'passno', 'opts', 'dump', 'fstab'):
         if module.params[key] is not None:
             args[key] = module.params[key]
-    if platform.system().lower() == 'linux':
-        # Linux has 'noauto' as mount opts to handle mount on boot
-        #  So boot option should manage 'noauto' in opts
-        # TODO: We need to support other system like *BSD that 'noauto' option available
+    if platform.system().lower() == 'linux' or platform.system().lower().endswith('bsd'):
+        # Linux, FreeBSD, NetBSD and OpenBSD have 'noauto' as mount option to
+        # handle mount on boot.  To avoid mount option conflicts, if 'noauto'
+        # specified in 'opts',  mount module will ignore 'boot'.
         opts = args['opts'].split(',')
         if 'noauto' in opts:
             args['warnings'].append("Ignore the 'boot' due to 'opts' contains 'noauto'.")


### PR DESCRIPTION
##### SUMMARY

Modify boot option handling on FreeBSD, NetBSD and OpenBSD systems

* Fixes #28 for BSD systems
* Porting PR #196 to BSD systems

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- plugins/modules/mount.py

##### ADDITIONAL INFORMATION
Tested on the following platforms:
- FreeBSD 13.0
- NetBSD 9.1
- OpenBSD 6.9