### PR TITLE
Add umask option for mount module

### DIFF
--- a/changelogs/fragments/209_add_mode_for_mount.yml
+++ b/changelogs/fragments/209_add_mode_for_mount.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- mount - add ``mode`` parameter to mount module (https://github.com/ansible-collections/ansible.posix/issues/163).
+- mount - add ``umask`` parameter to control permissions of the directories created by the module (https://github.com/ansible-collections/ansible.posix/issues/163).

--- a/changelogs/fragments/209_add_mode_for_mount.yml
+++ b/changelogs/fragments/209_add_mode_for_mount.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- mount - add mode option to mount module (https://github.com/ansible-collections/ansible.posix/issues/163).
+- mount - add ``mode`` parameter to mount module (https://github.com/ansible-collections/ansible.posix/issues/163).

--- a/changelogs/fragments/209_add_mode_for_mount.yml
+++ b/changelogs/fragments/209_add_mode_for_mount.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- mount - add mode option to mount module (https://github.com/ansible-collections/ansible.posix/issues/163).

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -827,12 +827,17 @@ def main():
                             if not (ex.errno == errno.EEXIST and os.path.isdir(b_curpath)):
                                 raise
 
-                if mode is not None:
-                    os.chmod(name, int(mode))
-
             except (OSError, IOError) as e:
                 module.fail_json(
                     msg="Error making dir %s: %s" % (name, to_native(e)))
+
+            # Set permissions to the newly created mount point.
+            if mode is not None:
+                try:
+                    changed = module.set_mode_if_different(name, mode, changed)
+                except Exception as e:
+                    module.fail_json(
+                        msg="Error setting permissions %s: %s" % (name, to_native(e)))
 
         name, backup_lines, changed = _set_mount_save_old(module, args)
         res = 0

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -115,7 +115,7 @@ options:
       - Note that after running this task and device being successfuly mounted,
         the mode of the original directory will be hidden by the target device.
     type: raw
-    required: false
+    version_added: '1.3.0'
 notes:
   - As of Ansible 2.3, the I(name) option has been changed to I(path) as
     default, but I(name) still works as well.

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -107,12 +107,12 @@ options:
     default: no
   mode:
     description:
-      - The permission applied to create a new directory for mount point.
+      - The permission applied to create a new directory for the mount point.
         If the mount point already exists, this parameter is not used.
-      - This parameter only affects to the mount point itself.
+      - This parameter only affects the mount point itself.
         If this module creates multiple directories recursively,
         other directories follow the system's default umask.
-      - Note that after running this task and device being successfuly mounted,
+      - Note that after running this task and the device being successfully mounted,
         the mode of the original directory will be hidden by the target device.
     type: raw
     required: false

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -801,7 +801,6 @@ def main():
 
             changed = True
     elif state == 'mounted':
-        
         dirs_created = []
         if not os.path.exists(name) and not module.check_mode:
             old_umask = None

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -811,7 +811,6 @@ def main():
                     except ValueError as e:
                         module.fail_json(msg="umask must be an octal integer: %s" % (to_native(e)))
                 old_umask = os.umask(umask)
-                os.umask(umask)
 
             try:
                 # Something like mkdir -p but with the possibility to undo.

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -332,3 +332,44 @@
     - /tmp/myfs.img
     - /tmp/myfs
   when: ansible_system in ('Linux')
+
+- name: Block to test mode option in Linux
+  block:
+  - name: Create empty file
+    community.general.filesize:
+      path: /tmp/myfs.img
+      size: 20M
+  - name: Format FS
+    community.general.filesystem:
+      fstype: ext3
+      dev: /tmp/myfs.img
+  - name: Make sure that mount point does not exist
+    file:
+      path: /tmp/myfs
+      state: absent
+  - name: Mount the FS to non existent directory with mode option
+    mount:
+      path: /tmp/myfs
+      src: /tmp/myfs.img
+      fstype: ext3
+      state: mounted
+      mode: 0000
+  - name: Unmount FS to access underlying directory
+    command: |
+      umount /tmp/myfs.img
+  - name: Check status of mount point
+    stat:
+      path: /tmp/myfs
+    register: mount_point_stat
+  - name: Assert that the mount point has right permission
+    assert:
+      that:
+      - mount_point_stat['stat']['mode'] == '0000'
+  - name: Remove the test FS
+    file:
+      path: '{{ item }}'
+      state: absent
+    loop:
+    - /tmp/myfs.img
+    - /tmp/myfs
+  when: ansible_system in ('Linux')

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -335,55 +335,37 @@
 
 - name: Block to test umask option
   block:
-  - name: Create empty file
-    community.general.filesize:
-      path: /tmp/myfs.img
-      size: 1M
-  - name: Format FS
-    community.general.filesystem:
-      fstype: ext3
-      dev: /tmp/myfs.img
-    when: ansible_system == 'Linux'
-  - name: Format FS
-    community.general.filesystem:
-      fstype: nullfs
-      dev: /tmp/myfs.img
-    when: ansible_system == 'FreeBSD'
   - name: Make sure that mount point does not exist
     file:
-      path: /tmp/myfs_mountpoint
+      path: /tmp/mount_dest
       state: absent
-
-  - name: Mount the FS to non existent directory with raw umask
+  - name: Create a directory to bind mount
+    file:
+      state: directory
+      path: /tmp/mount_source
+  - name: Bind mount a filesystem with umask
     mount:
-      path: /tmp/myfs_mountpoint
-      src: /tmp/myfs.img
-      fstype: ext3
+      src: /tmp/mount_source
+      path: /tmp/mount_dest
       state: mounted
+      fstype: None
+      opts: bind
       umask: 0777
-    when: ansible_system == 'Linux'
-  - name: Mount the FS to non existent directory with raw umask(FreeBSD)
+    when: ansible_system != 'FreeBSD'
+  - name: Bind mount a filesystem with umask(FreeBSD)
     mount:
-      path: /tmp/myfs_mountpoint
-      src: /tmp/myfs.img
-      fstype: nullfs
+      src: /tmp/mount_source
+      path: /tmp/mount_dest
       state: mounted
+      fstype: nullfs
       umask: 0777
     when: ansible_system == 'FreeBSD'
-  - name: Check status of parent directory of mount point
-    stat:
-      path: /tmp/foobar
-    register: parent_dir_stat
-  - name: Assert that the parent directory of the mount point has right permission
-    assert:
-      that:
-      - parent_dir_stat['stat']['mode'] == '0000'
   - name: Unmount FS to access underlying directory
     command: |
-      umount /tmp/myfs.img
-  - name: Check status of mount point
+      umount /tmp/mount_dest
+  - name: Stat mount point directory
     stat:
-      path: /tmp/myfs_mountpoint
+      path: /tmp/mount_dest
     register: mount_point_stat
   - name: Assert that the mount point has right permission
     assert:
@@ -391,128 +373,38 @@
       - mount_point_stat['stat']['mode'] == '0000'
   - name: Cleanup directory
     file:
-      path: /tmp/myfs_mountpoint
+      path: /tmp/mount_dest
       state: absent
-
-  - name: Mount the FS to non existent directory with string umask
+  - name: Bind mount a filesystem with string umask
     mount:
-      path: /tmp/myfs_mountpoint
-      src: /tmp/myfs.img
-      fstype: ext3
+      src: /tmp/mount_source
+      path: /tmp/mount_dest
       state: mounted
+      fstype: None
+      opts: bind
       umask: "0777"
-    when: ansible_system == 'Linux'
-  - name: Mount the FS to non existent directory with string umask(FreeBSD)
+    when: ansible_system != 'FreeBSD'
+  - name: Bind mount a filesystem with string umask(FreeBSD)
     mount:
-      path: /tmp/myfs_mountpoint
-      src: /tmp/myfs.img
-      fstype: nullfs
+      src: /tmp/mount_source
+      path: /tmp/mount_dest
       state: mounted
+      fstype: nullfs
       umask: "0777"
     when: ansible_system == 'FreeBSD'
-  - name: Check status of parent directory of mount point
-    stat:
-      path: /tmp/foobar
-    register: parent_dir_stat
-  - name: Assert that the parent directory of the mount point has right permission
-    assert:
-      that:
-      - parent_dir_stat['stat']['mode'] == '0000'
   - name: Unmount FS to access underlying directory
     command: |
-      umount /tmp/myfs.img
-  - name: Check status of mount point
+      umount /tmp/mount_dest
+  - name: Stat mount point directory
     stat:
-      path: /tmp/myfs_mountpoint
+      path: /tmp/mount_dest
     register: mount_point_stat
   - name: Assert that the mount point has right permission
     assert:
       that:
       - mount_point_stat['stat']['mode'] == '0000'
-  - name: Cleanup directory
-    file:
-      path: /tmp/myfs_mountpoint
-      state: absent
-
-  - name: Remount the FS to non existent directory with symbolic umask expression
-    mount:
-      path: /tmp/myfs_mountpoint
-      src: /tmp/myfs.img
-      fstype: ext3
-      state: mounted
-      umask: "u+rw,g-wx,o-rwx"
-    when: ansible_system == 'Linux'
-  - name: Remount the FS to non existent directory with symbolic umask expression(FreeBSD)
-    mount:
-      path: /tmp/myfs_mountpoint
-      src: /tmp/myfs.img
-      fstype: nullfs
-      state: mounted
-      umask: "u+rw,g-wx,o-rwx"
-    when: ansible_system == 'FreeBSD'
-  - name: Check status of parent directory of mount point
-    stat:
-      path: /tmp/foobar
-    register: parent_dir_stat
-  - name: Assert that the parent directory of the mount point has right permission
-    assert:
-      that:
-      - parent_dir_stat['stat']['mode'] == '0640'
-  - name: Unmount FS to access underlying directory
-    command: |
-      umount /tmp/myfs.img
-  - name: Check status of mount point
-    stat:
-      path: /tmp/myfs_mountpoint
-    register: mount_point_stat
-  - name: Assert that the mount point has right permission
-    assert:
-      that:
-      - mount_point_stat['stat']['mode'] == '0640'
-  - name: Cleanup directory
-    file:
-      path: /tmp/myfs_mountpoint
-      state: absent
-
-  - name: Remount the FS to non existent directory with symbolic umask expression
-    mount:
-      path: /tmp/myfs_mountpoint
-      src: /tmp/myfs.img
-      fstype: ext3
-      state: mounted
-      umask: "u=rw,g=r,o=r"
-    when: ansible_system == 'Linux'
-  - name: Remount the FS to non existent directory with symbolic umask expression(FreeBSD)
-    mount:
-      path: /tmp/myfs_mountpoint
-      src: /tmp/myfs.img
-      fstype: nullfs
-      state: mounted
-      umask: "u=rw,g=r,o=r"
-    when: ansible_system == 'FreeBSD'
-  - name: Check status of parent directory of mount point
-    stat:
-      path: /tmp/foobar
-    register: parent_dir_stat
-  - name: Assert that the parent directory of the mount point has right permission
-    assert:
-      that:
-      - parent_dir_stat['stat']['mode'] == '0644'
-  - name: Unmount FS to access underlying directory
-    command: |
-      umount /tmp/myfs.img
-  - name: Check status of mount point
-    stat:
-      path: /tmp/myfs_mountpoint
-    register: mount_point_stat
-  - name: Assert that the mount point has right permission
-    assert:
-      that:
-      - mount_point_stat['stat']['mode'] == '0644'
   - name: Remove the test FS
     file:
-      path: '{{ item }}'
+      path: /tmp/mount_dest
       state: absent
-    loop:
-    - /tmp/myfs.img
-    - /tmp/myfs_mountpoint
+  when: ansible_system not in ('MacOS')

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -333,43 +333,186 @@
     - /tmp/myfs
   when: ansible_system in ('Linux')
 
-- name: Block to test mode option in Linux
+- name: Block to test umask option
   block:
   - name: Create empty file
     community.general.filesize:
       path: /tmp/myfs.img
-      size: 20M
+      size: 1M
   - name: Format FS
     community.general.filesystem:
       fstype: ext3
       dev: /tmp/myfs.img
+    when: ansible_system == 'Linux'
+  - name: Format FS
+    community.general.filesystem:
+      fstype: nullfs
+      dev: /tmp/myfs.img
+    when: ansible_system == 'FreeBSD'
   - name: Make sure that mount point does not exist
     file:
-      path: /tmp/myfs
+      path: /tmp/myfs_mountpoint
       state: absent
-  - name: Mount the FS to non existent directory with mode option
+
+  - name: Mount the FS to non existent directory with raw umask
     mount:
-      path: /tmp/myfs
+      path: /tmp/myfs_mountpoint
       src: /tmp/myfs.img
       fstype: ext3
       state: mounted
-      mode: 0000
+      umask: 0777
+    when: ansible_system == 'Linux'
+  - name: Mount the FS to non existent directory with raw umask(FreeBSD)
+    mount:
+      path: /tmp/myfs_mountpoint
+      src: /tmp/myfs.img
+      fstype: nullfs
+      state: mounted
+      umask: 0777
+    when: ansible_system == 'FreeBSD'
+  - name: Check status of parent directory of mount point
+    stat:
+      path: /tmp/foobar
+    register: parent_dir_stat
+  - name: Assert that the parent directory of the mount point has right permission
+    assert:
+      that:
+      - parent_dir_stat['stat']['mode'] == '0000'
   - name: Unmount FS to access underlying directory
     command: |
       umount /tmp/myfs.img
   - name: Check status of mount point
     stat:
-      path: /tmp/myfs
+      path: /tmp/myfs_mountpoint
     register: mount_point_stat
   - name: Assert that the mount point has right permission
     assert:
       that:
       - mount_point_stat['stat']['mode'] == '0000'
+  - name: Cleanup directory
+    file:
+      path: /tmp/myfs_mountpoint
+      state: absent
+
+  - name: Mount the FS to non existent directory with string umask
+    mount:
+      path: /tmp/myfs_mountpoint
+      src: /tmp/myfs.img
+      fstype: ext3
+      state: mounted
+      umask: "0777"
+    when: ansible_system == 'Linux'
+  - name: Mount the FS to non existent directory with string umask(FreeBSD)
+    mount:
+      path: /tmp/myfs_mountpoint
+      src: /tmp/myfs.img
+      fstype: nullfs
+      state: mounted
+      umask: "0777"
+    when: ansible_system == 'FreeBSD'
+  - name: Check status of parent directory of mount point
+    stat:
+      path: /tmp/foobar
+    register: parent_dir_stat
+  - name: Assert that the parent directory of the mount point has right permission
+    assert:
+      that:
+      - parent_dir_stat['stat']['mode'] == '0000'
+  - name: Unmount FS to access underlying directory
+    command: |
+      umount /tmp/myfs.img
+  - name: Check status of mount point
+    stat:
+      path: /tmp/myfs_mountpoint
+    register: mount_point_stat
+  - name: Assert that the mount point has right permission
+    assert:
+      that:
+      - mount_point_stat['stat']['mode'] == '0000'
+  - name: Cleanup directory
+    file:
+      path: /tmp/myfs_mountpoint
+      state: absent
+
+  - name: Remount the FS to non existent directory with symbolic umask expression
+    mount:
+      path: /tmp/myfs_mountpoint
+      src: /tmp/myfs.img
+      fstype: ext3
+      state: mounted
+      umask: "u+rw,g-wx,o-rwx"
+    when: ansible_system == 'Linux'
+  - name: Remount the FS to non existent directory with symbolic umask expression(FreeBSD)
+    mount:
+      path: /tmp/myfs_mountpoint
+      src: /tmp/myfs.img
+      fstype: nullfs
+      state: mounted
+      umask: "u+rw,g-wx,o-rwx"
+    when: ansible_system == 'FreeBSD'
+  - name: Check status of parent directory of mount point
+    stat:
+      path: /tmp/foobar
+    register: parent_dir_stat
+  - name: Assert that the parent directory of the mount point has right permission
+    assert:
+      that:
+      - parent_dir_stat['stat']['mode'] == '0640'
+  - name: Unmount FS to access underlying directory
+    command: |
+      umount /tmp/myfs.img
+  - name: Check status of mount point
+    stat:
+      path: /tmp/myfs_mountpoint
+    register: mount_point_stat
+  - name: Assert that the mount point has right permission
+    assert:
+      that:
+      - mount_point_stat['stat']['mode'] == '0640'
+  - name: Cleanup directory
+    file:
+      path: /tmp/myfs_mountpoint
+      state: absent
+
+  - name: Remount the FS to non existent directory with symbolic umask expression
+    mount:
+      path: /tmp/myfs_mountpoint
+      src: /tmp/myfs.img
+      fstype: ext3
+      state: mounted
+      umask: "u=rw,g=r,o=r"
+    when: ansible_system == 'Linux'
+  - name: Remount the FS to non existent directory with symbolic umask expression(FreeBSD)
+    mount:
+      path: /tmp/myfs_mountpoint
+      src: /tmp/myfs.img
+      fstype: nullfs
+      state: mounted
+      umask: "u=rw,g=r,o=r"
+    when: ansible_system == 'FreeBSD'
+  - name: Check status of parent directory of mount point
+    stat:
+      path: /tmp/foobar
+    register: parent_dir_stat
+  - name: Assert that the parent directory of the mount point has right permission
+    assert:
+      that:
+      - parent_dir_stat['stat']['mode'] == '0644'
+  - name: Unmount FS to access underlying directory
+    command: |
+      umount /tmp/myfs.img
+  - name: Check status of mount point
+    stat:
+      path: /tmp/myfs_mountpoint
+    register: mount_point_stat
+  - name: Assert that the mount point has right permission
+    assert:
+      that:
+      - mount_point_stat['stat']['mode'] == '0644'
   - name: Remove the test FS
     file:
       path: '{{ item }}'
       state: absent
     loop:
     - /tmp/myfs.img
-    - /tmp/myfs
-  when: ansible_system in ('Linux')
+    - /tmp/myfs_mountpoint

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -407,4 +407,4 @@
     file:
       path: /tmp/mount_dest
       state: absent
-  when: ansible_system not in ('MacOS')
+  when: ansible_system not in ('Darwin')


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I added `mode` option for mount module.
When this module creates new directories for mount point, this value is used as permission of the directory.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #163, #178

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- mount

##### ADDITIONAL INFORMATION

When we want to set specific permission to the mount point directory, we can use `file` module. 
However once the filesystem is mounted, the underlying directory is nearly inaccessible, and cannot be modified by `file` module.
This is a bit inconvenient, so I added `mode` option so that permission can be set before actual mount operation.

In #163,  author requests to add `umask` option but when the mount point does not exist, this module creates directories, not files. So I think `mode` is more appropriate than `umask`.
