### PR TITLE
synchronize: quotes around arguments

### DIFF
--- a/changelogs/fragments/213_quote_cmd_args.yml
+++ b/changelogs/fragments/213_quote_cmd_args.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- Synchronize module not recognizing remote ssh key (https://github.com/ansible-collections/ansible.posix/issues/24).
+- Synchronize not using quotes around arguments like --out-format (https://github.com/ansible-collections/ansible.posix/issues/190).

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -548,10 +548,10 @@ def main():
             ssh_cmd_str = ' '.join(shlex_quote(arg) for arg in ssh_cmd)
             if ssh_args:
                 ssh_cmd_str += ' %s' % ssh_args
-            cmd.append('--rsh=%s' % ssh_cmd_str)
+            cmd.append(shlex_quote('--rsh=%s' % ssh_cmd_str))
 
     if rsync_path:
-        cmd.append('--rsync-path=%s' % rsync_path)
+        cmd.append(shlex_quote('--rsync-path=%s' % rsync_path))
 
     if rsync_opts:
         if '' in rsync_opts:
@@ -577,7 +577,7 @@ def main():
             cmd.append('--link-dest=%s' % link_path)
 
     changed_marker = '<<CHANGED>>'
-    cmd.append('--out-format=' + changed_marker + '%i %n%L')
+    cmd.append(shlex_quote('--out-format=' + changed_marker + '%i %n%L'))
 
     # expand the paths
     if '@' not in source:
@@ -601,10 +601,10 @@ def main():
                     raise
 
         (rc, out, err) = module.run_command(
-            cmd, pass_fds=_sshpass_pipe,
+            cmdstr, pass_fds=_sshpass_pipe,
             before_communicate_callback=_write_password_to_pipe)
     else:
-        (rc, out, err) = module.run_command(cmd)
+        (rc, out, err) = module.run_command(cmdstr)
 
     if rc:
         return module.fail_json(msg=err, rc=rc, cmd=cmdstr)

--- a/tests/integration/targets/synchronize/aliases
+++ b/tests/integration/targets/synchronize/aliases
@@ -1,2 +1,1 @@
 shippable/posix/group1
-disabled # fixme package


### PR DESCRIPTION
fix quoting for specific cmd arguments

Fixes:
- #24
- #190 

ISSUE TYPE:
- Bugfix Pull Request

COMPONENT NAME:
  module: synchronize
