### PR TITLE
fix REJECT target name

### DIFF
--- a/changelogs/fragments/215_fix_REJECT_target_name.yml
+++ b/changelogs/fragments/215_fix_REJECT_target_name.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - firewalld - fix setting target to REJECT ( https://github.com/ansible-collections/ansible.posix/pull/215 )
+  - firewalld - fix setting zone target to ``%%REJECT%%`` (https://github.com/ansible-collections/ansible.posix/pull/215).

--- a/changelogs/fragments/215_fix_REJECT_target_name.yml
+++ b/changelogs/fragments/215_fix_REJECT_target_name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - firewalld - fix setting target to REJECT ( https://github.com/ansible-collections/ansible.posix/pull/215 )

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -114,7 +114,7 @@ options:
     description:
       - firewalld Zone target
       - If state is set to C(absent), this will reset the target to default
-    choices: [ default, ACCEPT, DROP, %%REJECT%% ]
+    choices: [ default, ACCEPT, DROP, "%%REJECT%%" ]
     type: str
     version_added: 1.2.0
 notes:

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -114,7 +114,7 @@ options:
     description:
       - firewalld Zone target
       - If state is set to C(absent), this will reset the target to default
-    choices: [ default, ACCEPT, DROP, REJECT ]
+    choices: [ default, ACCEPT, DROP, %%REJECT%% ]
     type: str
     version_added: 1.2.0
 notes:
@@ -748,7 +748,7 @@ def main():
             interface=dict(type='str'),
             masquerade=dict(type='str'),
             offline=dict(type='bool'),
-            target=dict(type='str', choices=['default', 'ACCEPT', 'DROP', 'REJECT']),
+            target=dict(type='str', choices=['default', 'ACCEPT', 'DROP', '%%REJECT%%']),
         ),
         supports_check_mode=True,
         required_by=dict(

--- a/tests/integration/targets/firewalld/tasks/zone_target_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/zone_target_test_cases.yml
@@ -67,3 +67,55 @@
   assert:
     that:
     - result is not changed
+
+- name: firewalld dmz zone target %%REJECT%%
+  firewalld:
+    zone: dmz
+    permanent: True
+    state: present
+    target: '%%REJECT%%'
+  register: result
+
+- name: assert firewalld dmz zone target %%REJECT%% present worked
+  assert:
+    that:
+    - result is changed
+
+- name: firewalld dmz zone target %%REJECT%% rerun (verify not changed)
+  firewalld:
+    zone: dmz
+    permanent: True
+    state: present
+    target: '%%REJECT%%'
+  register: result
+
+- name: assert firewalld dmz zone target %%REJECT%% present worked (verify not changed)
+  assert:
+    that:
+    - result is not changed
+
+- name: firewalld dmz zone target %%REJECT%% absent
+  firewalld:
+    zone: dmz
+    permanent: True
+    state: absent
+    target: '%%REJECT%%'
+  register: result
+
+- name: assert firewalld dmz zone target %%REJECT%% absent worked
+  assert:
+    that:
+    - result is changed
+
+- name: firewalld dmz zone target %%REJECT%% rerun (verify not changed)
+  firewalld:
+    zone: dmz
+    permanent: True
+    state: absent
+    target: '%%REJECT%%'
+  register: result
+
+- name: assert firewalld dmz zone target %%REJECT%% present worked (verify not changed)
+  assert:
+    that:
+    - result is not changed


### PR DESCRIPTION
##### SUMMARY
Fix setting default target to reject. The target name is %%REJECT%% not REJECT.
https://firewalld.org/documentation/zone/options.html

After this pull request to way to set REJECT would be
```paste below
  - name: "Set target to REJECT for public"
    ansible.posix.firewalld:
      zone: public
      permanent: yes
      target: '%%REJECT%%'
      state: enabled
    become: true
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
firewalld

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
This snippet would fail due to there not being target called REJECT and using %%REJECT%% is not in allowed values for target
```paste below
  - name: "Set target to REJECT for public"
    ansible.posix.firewalld:
      zone: public
      permanent: yes
      target: 'REJECT'
      state: enabled
    become: true
```
Ansible error
```paste below
{
    "msg": "ERROR: Exception caught: org.fedoraproject.FirewallD1.Exception: INVALID_TARGET: REJECT Permanent operation",
    "invocation": {
        "module_args": {
            "zone": "public",
            "permanent": true,
            "target": "REJECT",
            "state": "enabled",
            "immediate": false,
            "timeout": 0,
            "icmp_block": null,
            "icmp_block_inversion": null,
            "service": null,
            "port": null,
            "port_forward": null,
            "rich_rule": null,
            "source": null,
            "interface": null,
            "masquerade": null,
            "offline": null
        }
    },
    "_ansible_no_log": false,
    "changed": false
}
```
syslog
```paste below
Jun 29 09:49:39 <hostname retracted> ansible-ansible.posix.firewalld[9015]: Invoked with zone=public permanent=True state=enabled target=REJECT immediate=False timeout=0 icmp_[1850/7279] icmp_block_inversion=None service=None port=None port_forward=None rich_rule=None source=None interface=None masquerade=None offline=None                                                                 
Jun 29 09:49:39 <hostname retracted>  firewalld[915]: ERROR: INVALID_TARGET: REJECT
```
