### PR TITLE
synchronize: Use SSH args from SSH connection plugins

### DIFF
--- a/changelogs/fragments/222_synchronize.yml
+++ b/changelogs/fragments/222_synchronize.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- synchronize - use SSH args from SSH connection plugin (https://github.com/ansible-collections/ansible.posix/issues/222).

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -137,7 +137,9 @@ options:
     default: yes
   use_ssh_args:
     description:
-      - Use the ssh_args specified in ansible.cfg. Setting this to `yes` will also make `synchronize` use `ansible_ssh_common_args`.
+      - In Ansible 2.10 and lower, it uses the ssh_args specified in C(ansible.cfg).
+      - In Ansible 2.11 and onwards, when set to C(true), it uses all SSH connection configurations like
+        C(ansible_ssh_args), C(ansible_ssh_common_args), and C(ansible_ssh_extra_args).
     type: bool
     default: no
   ssh_connection_multiplexing:


### PR DESCRIPTION
##### SUMMARY

SSH configuration migrated from Ansible configuration to
SSH connection configuration. Make ``synchronize`` understand
this.

Fixes: #222

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/222_synchronize.yml
plugins/action/synchronize.py
plugins/modules/synchronize.py
