### PR TITLE
Fix: sysctl integration test - virtualization type

### DIFF
--- a/changelogs/fragments/226_sysctl_fix_integration_test.yml
+++ b/changelogs/fragments/226_sysctl_fix_integration_test.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- sysctl - modifying conditional check for docker to fix tests being skipped (https://github.com/ansible-collections/ansible.posix/pull/226).

--- a/tests/integration/targets/sysctl/tasks/main.yml
+++ b/tests/integration/targets/sysctl/tasks/main.yml
@@ -22,7 +22,7 @@
 
 - name: Test inside Docker
   when:
-    - ansible_facts.virtualization_type == 'docker'
+    - ansible_facts.virtualization_type == 'docker' or ansible_facts.virtualization_type == 'container'
   block:
     - set_fact:
         output_dir_test: "{{ output_dir }}/test_sysctl"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
sysctl integration tests inside docker are being skipped as the check ansible_facts.virtualization_type == 'docker' fails. 
On Debugging, ansible_facts.virtualization_type is being returned as "container".

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sysctl

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Ansible Version 
- ansible [core 2.11.2] 

Docker Version 
- Docker version 20.10.7, build f0df350

OS
- Fedora 34

Actual Results
```
PLAY RECAP *********************************************************************
testhost                   : ok=1    changed=0    unreachable=0    failed=0    skipped=44   rescued=0    ignored=0   
```

Likely this code is related: https://github.com/ansible/ansible/blob/devel/lib/ansible/module_utils/facts/virtual/linux.py#L113

