### PR TITLE
Fixed job delete logic to cover RHEL6, CentOS6, *BSD and Solaris

### DIFF
--- a/changelogs/fragments/228-at_fix_delete_logic.yml
+++ b/changelogs/fragments/228-at_fix_delete_logic.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - at - use ``atrm`` command instead of ``at -r`` to avoid ``invalid option`` error on ``RHEL6`` and ``CentOS6``.
+  - at - fixed search logic for job_id to perform correctly on ``*BSD`` and Solaris.

--- a/tests/integration/targets/at/aliases
+++ b/tests/integration/targets/at/aliases
@@ -1,3 +1,2 @@
 shippable/posix/group1
 destructive
-disabled # fixme package

--- a/tests/integration/targets/at/tasks/main.yml
+++ b/tests/integration/targets/at/tasks/main.yml
@@ -28,7 +28,7 @@
 ## at
 ##
 
-- name: define distros to attempt installing at on 
+- name: define distros to attempt installing at on
   set_fact:
     package_distros:
         - RedHat
@@ -51,8 +51,8 @@
     count: 20
     units: minutes
   register: at_test0
-- debug: var=at_test0
-- name: validate results
+
+- name: validate results for schedule creation
   assert:
       that:
           - 'at_test0.changed is defined'
@@ -60,3 +60,15 @@
           - 'at_test0.script_file is defined'
           - 'at_test0.state is defined'
           - 'at_test0.units is defined'
+
+- name: remove first example schedule
+  at:
+    command: "ls -d / > /dev/null"
+    state: absent
+  register: at_test1
+
+- name: validate results for schedule deletion
+  assert:
+      that:
+          - 'at_test1.changed'
+          - 'at_test1.state == "absent"'


### PR DESCRIPTION
##### SUMMARY

* `at -r` command-line option does not work on RHEL6 and CentOS6. Therefore, we will need to modify delete logic to use `atrm` command instead of `at -r`.
* Fixed search logic for job_id to perform correctly on *BSD and Solaris.

##### ISSUE TYPE
- Bugfix Pull Request
- Fixes #218 (CI tests issue with CentOS6)
 
##### COMPONENT NAME
- ansible.posix.at

##### ADDITIONAL INFORMATION
* RHEL6 and CentOS6 does not have `at -r` option:
```
$ cat /etc/redhat-release 
Red Hat Enterprise Linux Server release 6.10 (Santiago)
$ at -r
at: invalid option -- 'r'
Usage: at [-V] [-q x] [-f file] [-mMlbv] timespec ...
       at [-V] [-q x] [-f file] [-mMlbv] -t time
       at -c job ...
       atq [-V] [-q x]
       at [ -rd ] job ...
       atrm [-V] job ...
       batch
```
* The order of the job id number in the output column of `atq` on FreeBSD are different from Linux. We need to take care of the difference of job id position.
```
FreeBSD and NetBSD: job id is located at the end of the columns.
~~~
Date				Owner		Queue	Job#
Wed Dec 31 00:00:00 UTC 2200	root            c	9
~~~

OpenBSD: job id is located in the middle of the columns.
~~~
   Rank     Execution Date     Owner          Job       Queue
  1st   Jan  1, 2022 00:00   root       1640962800.c   c
~~~

Solaris: job id is located in the middle of the columns
~~~
 Rank     Execution Date     Owner      Job            Queue   Job Name
  1st   Jan  1, 2022 00:00   root       1640962800.a     a     stdin
~~~

Linux: job id is located at the beginning of the columns.
~~~
26	2022-01-01 00:00 a root
~~~
```
* `at -c` is different behavior on Solaris. So we need to read /var/spool/cron/atjobs/<job_id> to confirm the job details instead of `at -c` on Solaris nodes.
