### PR TITLE
Allow podman connections in synchronize module

### DIFF
--- a/changelogs/fragments/229_add_podman_connection_plugin_to_synchronize.yml
+++ b/changelogs/fragments/229_add_podman_connection_plugin_to_synchronize.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - synchronize - add ``community.podman.podman`` to the list of supported
+  - synchronize - add ``community.podman.podman`` to the list of supported connection plugins (https://github.com/ansible-community/molecule-podman/issues/45).

--- a/changelogs/fragments/229_add_podman_connection_plugin_to_synchronize.yml
+++ b/changelogs/fragments/229_add_podman_connection_plugin_to_synchronize.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - synchronize - add ``community.podman.podman`` to the list of supported

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -66,7 +66,15 @@ class ActionModule(ActionBase):
             return path
 
         # If using docker or buildah, do not add user information
-        if self._remote_transport not in ['docker', 'community.general.docker', 'community.docker.docker', 'buildah', 'containers.podman.buildah'] and user:
+        if self._remote_transport not in [
+            'docker',
+            'community.general.docker',
+            'community.docker.docker',
+            'buildah',
+            'containers.podman.buildah',
+            'podman',
+            'containers.podman.podman'
+        ] and user:
             user_prefix = '%s@' % (user, )
 
         if self._host_is_ipv6_address(host):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request
For fixing issues with molecule: https://github.com/ansible-community/molecule-podman/issues/45

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
synchronize
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Add `podman` connections as it's done with buildah and docker.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

