### PR TITLE
Fix requires firewalld version in comments for permanent parameter.

### DIFF
--- a/changelogs/fragments/233-fix-wrong-firewalld-version-info.yml
+++ b/changelogs/fragments/233-fix-wrong-firewalld-version-info.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - firewalld - fix wrong version number in the module document.

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -81,7 +81,7 @@ options:
   permanent:
     description:
       - Should this configuration be in the running firewalld configuration or persist across reboots.
-      - As of Ansible 2.3, permanent operations can operate on firewalld configs when it is not running (requires firewalld >= 3.0.9).
+      - As of Ansible 2.3, permanent operations can operate on firewalld configs when it is not running (requires firewalld >= 0.3.9).
       - Note that if this is C(no), immediate is assumed C(yes).
     type: bool
   immediate:


### PR DESCRIPTION
##### SUMMARY
Version of firewalled seems to be wrong. 3.0.9 version of that package does not exist.
The latest release of firewalled: https://github.com/firewalld/firewalld/releases

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
ansible.posix.firewalld

```
