### PR TITLE
Properly quote Synchronize

### DIFF
--- a/changelogs/fragments/241-synchronize-shell-quoting.yml
+++ b/changelogs/fragments/241-synchronize-shell-quoting.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - synchronize - properly quote rsync CLI parameters (https://github.com/ansible-collections/ansible.posix/pull/241).

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -21,6 +21,7 @@ import os.path
 
 from ansible import constants as C
 from ansible.module_utils.six import string_types
+from ansible.module_utils.six.moves import shlex_quote
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common._collections_compat import MutableSequence
 from ansible.module_utils.parsing.convert_bool import boolean
@@ -414,13 +415,13 @@ class ActionModule(ActionBase):
 
             if self._remote_transport in DOCKER + PODMAN:
                 if become and self._play_context.become_user:
-                    _tmp_args['rsync_opts'].append("--rsh=%s exec -u %s -i" % (self._docker_cmd, self._play_context.become_user))
+                    _tmp_args['rsync_opts'].append('--rsh=' + shlex_quote('%s exec -u %s -i' % (self._docker_cmd, self._play_context.become_user)))
                 elif user is not None:
-                    _tmp_args['rsync_opts'].append("--rsh=%s exec -u %s -i" % (self._docker_cmd, user))
+                    _tmp_args['rsync_opts'].append('--rsh=' + shlex_quote('%s exec -u %s -i' % (self._docker_cmd, user)))
                 else:
-                    _tmp_args['rsync_opts'].append("--rsh=%s exec -i" % self._docker_cmd)
+                    _tmp_args['rsync_opts'].append('--rsh=' + shlex_quote('%s exec -i' % self._docker_cmd))
             elif self._remote_transport in BUILDAH:
-                _tmp_args['rsync_opts'].append("--rsh=buildah run --")
+                _tmp_args['rsync_opts'].append('--rsh=' + shlex_quote('buildah run --'))
 
         # run the module and store the result
         result.update(self._execute_module('ansible.posix.synchronize', module_args=_tmp_args, task_vars=task_vars))

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -548,10 +548,10 @@ def main():
             ssh_cmd_str = ' '.join(shlex_quote(arg) for arg in ssh_cmd)
             if ssh_args:
                 ssh_cmd_str += ' %s' % ssh_args
-            cmd.append(shlex_quote('--rsh=%s' % ssh_cmd_str))
+            cmd.append('--rsh=%s' % shlex_quote(ssh_cmd_str))
 
     if rsync_path:
-        cmd.append(shlex_quote('--rsync-path=%s' % rsync_path))
+        cmd.append('--rsync-path=%s' % shlex_quote(rsync_path))
 
     if rsync_opts:
         if '' in rsync_opts:
@@ -577,7 +577,7 @@ def main():
             cmd.append('--link-dest=%s' % link_path)
 
     changed_marker = '<<CHANGED>>'
-    cmd.append(shlex_quote('--out-format=' + changed_marker + '%i %n%L'))
+    cmd.append('--out-format=%s' % shlex_quote(changed_marker + '%i %n%L'))
 
     # expand the paths
     if '@' not in source:


### PR DESCRIPTION
##### SUMMARY

The synchronize action plugin and module were a bit sloppy when it came to the command-line parameter quoting and that caused failure on some systems (for example, on Fedora 34).

This commit makes sure any arguments with potentially problematic characters are quoted before being used.

Fixes https://github.com/ansible-collections/ansible.posix/issues/242

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

synchronize
