### PR TITLE
firewalld: Correct usage of queryForwardPort

### DIFF
--- a/changelogs/fragments/247_firewalld.yml
+++ b/changelogs/fragments/247_firewalld.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- firewalld - Correct usage of queryForwardPort (https://github.com/ansible-collections/ansible.posix/issues/247).

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -706,7 +706,7 @@ class ForwardPortTransaction(FirewallTransaction):
         if self.fw_offline:
             dummy, fw_settings = self.get_fw_zone_settings()
             return fw_settings.queryForwardPort(port=port, protocol=proto, to_port=toport, to_addr=toaddr)
-        return self.fw.queryForwardPort(port=port, protocol=proto, to_port=toport, to_addr=toaddr)
+        return self.fw.queryForwardPort(zone=self.zone, port=port, protocol=proto, toport=toport, toaddr=toaddr)
 
     def get_enabled_permanent(self, port, proto, toport, toaddr, timeout):
         dummy, fw_settings = self.get_fw_zone_settings()

--- a/tests/integration/targets/firewalld/tasks/run_all_tests.yml
+++ b/tests/integration/targets/firewalld/tasks/run_all_tests.yml
@@ -14,7 +14,10 @@
 - include_tasks: port_test_cases.yml
 
 # firewalld source operation test cases
-- import_tasks: source_test_cases.yml
+- include_tasks: source_test_cases.yml
 
 # firewalld zone target operation test cases
-- import_tasks: zone_target_test_cases.yml
+- include_tasks: zone_target_test_cases.yml
+
+# firewalld port forwarding operation test cases
+- include_tasks: port_forward_test_cases.yml


### PR DESCRIPTION
##### SUMMARY

* Correct queryForwardPort API usage
* Enable port_foward_test_cases tests

Fixes: #247

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/modules/firewalld.py
tests/integration/targets/firewalld/tasks/run_all_tests.yml
