### PR TITLE
firewalld - announce breaking changes

### DIFF
--- a/changelogs/fragments/firewalld_breaking_change.yml
+++ b/changelogs/fragments/firewalld_breaking_change.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+- firewalld - ``icmp_block_inversion`` and ``masquerade`` will be changed to ``bool`` from ``str``. Please change playbooks accordingly (https://github.com/ansible-collections/ansible.posix/issues/235).


### PR DESCRIPTION
##### SUMMARY

* ``masquerade`` and ``icmp_block_inversion`` will be changed from ``str`` to ``bool``

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/firewalld_breaking_change.yml
