### PR TITLE
DO NOT MERGE (test about ansible_virtualization_type)

### DIFF
--- a/tests/integration/targets/sysctl/tasks/main.yml
+++ b/tests/integration/targets/sysctl/tasks/main.yml
@@ -20,6 +20,12 @@
 # apply sysctl, or it will always fail, because of that in most cases (except
 # those when it should fail) we have to use `reload=no`.
 
+
+- name: Display ansible_virtualization_type
+  debug:
+    var: ansible_facts.virtualization_type
+
+
 - name: Test inside Docker
   when:
     - ansible_facts.virtualization_type == 'docker' or ansible_facts.virtualization_type == 'container'


### PR DESCRIPTION
##### SUMMARY

This is to understand why `ansible_facts.virtualization_type` is not `docker` on Docker (for only a few hosts)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

sysctl

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
