### PR TITLE
Display warning message for masquerade and icmp-block-inversion

### DIFF
--- a/changelogs/fragments/254_variable_warnings.yml
+++ b/changelogs/fragments/254_variable_warnings.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+- firewalld - Show warning message that variable type of ``masquerade`` and
+  ``icmp_block_inversion`` will be changed from ``str`` to ``boolean``
+  in the future release (https://github.com/ansible-collections/ansible.posix/pull/254).

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -213,6 +213,7 @@ EXAMPLES = r'''
 '''
 
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.parsing.convert_bool import boolean
 from ansible_collections.ansible.posix.plugins.module_utils.firewalld import FirewallTransaction, fw_offline
 
 try:
@@ -875,6 +876,14 @@ def main():
         if changed is True:
             msgs.append("Changed icmp-block-inversion %s to %s" % (icmp_block_inversion, desired_state))
 
+        # Type of icmp_block_inversion will be changed to boolean in a future release.
+        try:
+            boolean(icmp_block_inversion, True)
+        except TypeError:
+            module.warn('The value of the icmp_block_inversion option is "%s". '
+                        'The type of the option will be changed from string to boolean in a future release. '
+                        'To avoid unexpected behavior, please change the value to boolean.' % icmp_block_inversion)
+
     if service is not None:
 
         transaction = ServiceTransaction(
@@ -991,6 +1000,14 @@ def main():
 
         changed, transaction_msgs = transaction.run()
         msgs = msgs + transaction_msgs
+
+        # Type of masquerade will be changed to boolean in a future release.
+        try:
+            boolean(masquerade, True)
+        except TypeError:
+            module.warn('The value of the masquerade option is "%s". '
+                        'The type of the option will be changed from string to boolean in a future release. '
+                        'To avoid unexpected behavior, please change the value to boolean.' % masquerade)
 
     if target is not None:
 


### PR DESCRIPTION
##### SUMMARY

Display warning message if the wrong parameter set to `masquerade` or `icmp-block-inversion`

* Fixes #249

It is a part of #249. Currently, the variable type of the above two parameters is `str`, but will be `changed` to bool in the future. As a starting point, this fix displays a warning message if a non-boolean value is specified.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ansible.posix.firewalld

##### ADDITIONAL INFORMATION
```
None
```
