### PR TITLE
authorized_key: add lookup.url example

### DIFF
--- a/changelogs/fragments/255_authorized_key_url.yml
+++ b/changelogs/fragments/255_authorized_key_url.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- authorized_keys - add example involving lookup.url

--- a/changelogs/fragments/255_authorized_key_url.yml
+++ b/changelogs/fragments/255_authorized_key_url.yml
@@ -1,3 +1,3 @@
 ---
 trivial:
-- authorized_keys - add example involving lookup.url
+- authorized_keys - add an example involving ``url`` lookup plugin (https://github.com/ansible-collections/ansible.posix/pull/260).

--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -94,6 +94,12 @@ EXAMPLES = r'''
     state: present
     key: https://github.com/charlie.keys
 
+- name: Set authorized keys taken from url using lookup
+  ansible.posix.authorized_key:
+    user: charlie
+    state: present
+    key: "{{ lookup('url', 'https://github.com/charlie.keys', split_lines=False) }}"
+
 - name: Set authorized key in alternate location
   ansible.posix.authorized_key:
     user: charlie


### PR DESCRIPTION
##### SUMMARY
Add lookup.url example since using `split_lines=False` is not straight-forward.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ansible.posix.authorized_key

