### PR TITLE
Add ephemeral state to mount fs without altering fstab

### DIFF
--- a/changelogs/fragments/264_mount_ephemeral.yml
+++ b/changelogs/fragments/264_mount_ephemeral.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+- mount - Add ``ephemeral`` value for the ``state`` parameter, that allows to mount a filesystem
+  without altering the ``fstab`` file (https://github.com/ansible-collections/ansible.posix/pull/xxx).

--- a/changelogs/fragments/264_mount_ephemeral.yml
+++ b/changelogs/fragments/264_mount_ephemeral.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
 - mount - Add ``ephemeral`` value for the ``state`` parameter, that allows to mount a filesystem
-  without altering the ``fstab`` file (https://github.com/ansible-collections/ansible.posix/pull/xxx).
+  without altering the ``fstab`` file (https://github.com/ansible-collections/ansible.posix/pull/264).

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -460,6 +460,7 @@ def _set_ephemeral_args(args):
 
     return result
 
+
 def mount(module, args):
     """Mount up a path or remount if needed."""
 
@@ -726,6 +727,7 @@ def _is_same_mount_src(module, args, mntinfo_file="/proc/self/mountinfo"):
 
     # (dst == mountpoint and src == name) was never reached
     return False
+
 
 def main():
     module = AnsibleModule(

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -648,7 +648,7 @@ def _get_mount_info(module, mntinfo_file="/proc/self/mountinfo"):
 def get_linux_mounts(module, mntinfo_file="/proc/self/mountinfo"):
     """Gather mount information"""
 
-    lines = _get_mount_info(module)
+    lines = _get_mount_info(module, mntinfo_file)
     # Keep same behavior than before
     if lines is None:
         return


### PR DESCRIPTION
##### SUMMARY

Add `ephemeral` possible value for `state` parameter.

The `ephemeral` state allows end-users to mount a volume on a given path, without altering an `fstab` file or creating a dummy one.

There have been debates about splitting this module into an `fstab` module and a `mount` module, but nothing has been done in 5 years. This is why I'd like to propose this feature.

**Downside**: the way the `posix.mount` module handles the mount options prevent it to be able to check exactly if the given `opts` perfectly match the mount options of an already mounted volume. To achieve this, the module would have to be aware of every `mount` default options, for all platforms. This is why the `ephemeral` state always return `changed=yes`. In other terms, a `remount` will always be triggered if the volume is already mounted, even if the options look to be the same. However, using *state* `unmounted` on a volume previously mounted with `ephemeral` behaves correctly.

##### ISSUE TYPE

- Feature Pull Request

Related issues:
-  [ansible/ansible#48134](https://github.com/ansible/ansible/issues/48134)
- #84 

##### COMPONENT NAME

mount

##### ADDITIONAL INFORMATION

**Example use case**

Sometimes it is handy to be able to temporarily mount a volume. I've seen this in some companies where they use Ansible to generate reports and put it on network shares. However, some admins don't look into mount options such as krb5 and multiuser for SMB shares. Being forced to use fstab-based mounts leads to clear text passwords being stored more or less temporarily on the host filesystem, requiring "manual" deletion (with the hassle of using blocks, rescues, always, etc.). This feature respond to this use case by providing a way to mount a volume without having to alter an fstab file.

**Description of changes**

- Edit DOCUMENTATION section to add ephemeral state
- Edit EXAMPLES section to add ephemeral state example
- Add new function `_set_ephemeral_args` to use instead of `_set_fstab_args` when using ephemeral state
- Add new function `_is_same_mount_src` to determine if the mounted volume on the destination path has the same source than the one supplied to the module
- Add new function `_get_mount_info` to avoid redundant code between functions `get_linux_mounts` and `_is_same_mount_src`
- Modify `get_linux_mount` to use the new function `_get_mount_info`. Behavior is preserved.
- Integrate `ephemeral` parameter treatment into `mounted` treatment, and add `if` statements to avoid IO from/to fstab
- Add `ephemeral` as a possible value for the `state` parameter in `main()`
- Add `required_if` dependencies for `ephemeral` state
