### PR TITLE
Add bindep.txt file for execution environments

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,4 @@
+# This is a cross-platform list tracking distribution packages needed by tests;
+# see https://docs.openstack.org/infra/bindep/ for additional information.
+
+rsync [platform:centos-8 platform:rhel-8]


### PR DESCRIPTION
This adds rsync to the bindep.txt file, which will ensure rsync is
installed as a dependency for execution environments.

Signed-off-by: Paul Belanger <pabelanger@redhat.com>