### PR TITLE
CI: remove centos8 from test matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -53,8 +53,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 33
               test: fedora33
             - name: Fedora 34


### PR DESCRIPTION
##### SUMMARY
Remove centos8 from CI matrix.

References: https://github.com/ansible-collections/overview/issues/45#issuecomment-944657318

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
- .azure-pipelines/azure-pipelines.yml

##### ADDITIONAL INFORMATION
None
