### PR TITLE
Fix unit test for synchronize action plugin

### DIFF
--- a/changelogs/fragments/282_fix_unit_test_for_synchronize.yml
+++ b/changelogs/fragments/282_fix_unit_test_for_synchronize.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- Fix unit tests of synchronize action plugin to use yaml.safe_load().

--- a/tests/unit/plugins/action/test_synchronize.py
+++ b/tests/unit/plugins/action/test_synchronize.py
@@ -125,7 +125,7 @@ class SynchronizeTester(object):
         metapath = os.path.join(fixturepath, 'meta.yaml')
         with open(metapath, 'rb') as f:
             fdata = f.read()
-        test_meta = yaml.load(fdata)
+        test_meta = yaml.safe_load(fdata)
 
         # load initial play context vars
         if '_play_context' in test_meta:


### PR DESCRIPTION
##### SUMMARY
Fix unit test for synchronize action plugin to use yaml.safe_load() instead of yaml.load()

##### ISSUE TYPE
- CI test Pull Request

##### COMPONENT NAME
- tests/unit/plugins/action/test_synchronize.py

##### ADDITIONAL INFORMATION
Address to the following CI test issue:

```shell
tests/unit/modules/system/test_mount.py::LinuxMountsTestCase::test_code_comment 
[gw0] [  7%] PASSED tests/unit/modules/system/test_mount.py::LinuxMountsTestCase::test_code_comment 
tests/unit/modules/system/test_mount.py::LinuxMountsTestCase::test_set_mount_save_old 
[gw0] [ 14%] PASSED tests/unit/modules/system/test_mount.py::LinuxMountsTestCase::test_set_mount_save_old 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic 
[gw0] [ 21%] FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_become 
[gw0] [ 28%] FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_become 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_become_cli 
[gw0] [ 35%] FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_become_cli 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_vagrant 
[gw0] [ 42%] FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_vagrant 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_vagrant_become_cli 
[gw0] [ 50%] FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_vagrant_become_cli 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_vagrant_sudo 
[gw0] [ 57%] FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_vagrant_sudo 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_with_private_key 
[gw0] [ 64%] FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_with_private_key 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote 
[gw0] [ 71%] FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote_play_context_private_key 
[gw0] [ 78%] FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote_play_context_private_key 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote_su 
[gw0] [ 85%] FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote_su 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote_with_private_key 
[gw0] [ 92%] FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote_with_private_key 
tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_remote_user_not_in_local_tmpdir 
[gw0] [100%] PASSED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_remote_user_not_in_local_tmpdir 

=================================== FAILURES ===================================
_______________________ TestSynchronizeAction.test_basic _______________________
[gw0] linux -- Python 3.8.0 /tmp/python-55ij_ymk-ansible/python
self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.TestSynchronizeAction testMethod=test_basic>

    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
    def test_basic(self):
        x = SynchronizeTester()
>       x.runtest(fixturepath=os.path.join(self.fixturedir, 'basic'))

tests/unit/plugins/action/test_synchronize.py:215: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.SynchronizeTester object at 0x7fe1356c64f0>
fixturepath = '/home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/unit/plugins/action/fixtures/synchronize/basic'

    def runtest(self, fixturepath='fixtures/synchronize/basic'):
    
        metapath = os.path.join(fixturepath, 'meta.yaml')
        with open(metapath, 'rb') as f:
            fdata = f.read()
>       test_meta = yaml.load(fdata)
E       TypeError: load() missing 1 required positional argument: 'Loader'

tests/unit/plugins/action/test_synchronize.py:128: TypeError
___________________ TestSynchronizeAction.test_basic_become ____________________
[gw0] linux -- Python 3.8.0 /tmp/python-55ij_ymk-ansible/python
self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.TestSynchronizeAction testMethod=test_basic_become>

    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
    def test_basic_become(self):
        x = SynchronizeTester()
>       x.runtest(fixturepath=os.path.join(self.fixturedir, 'basic_become'))

tests/unit/plugins/action/test_synchronize.py:220: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.SynchronizeTester object at 0x7fe1356c65b0>
fixturepath = '/home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/unit/plugins/action/fixtures/synchronize/basic_become'

    def runtest(self, fixturepath='fixtures/synchronize/basic'):
    
        metapath = os.path.join(fixturepath, 'meta.yaml')
        with open(metapath, 'rb') as f:
            fdata = f.read()
>       test_meta = yaml.load(fdata)
E       TypeError: load() missing 1 required positional argument: 'Loader'

tests/unit/plugins/action/test_synchronize.py:128: TypeError
_________________ TestSynchronizeAction.test_basic_become_cli __________________
[gw0] linux -- Python 3.8.0 /tmp/python-55ij_ymk-ansible/python
self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.TestSynchronizeAction testMethod=test_basic_become_cli>

    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
    def test_basic_become_cli(self):
        # --become on the cli sets _play_context.become
        x = SynchronizeTester()
>       x.runtest(fixturepath=os.path.join(self.fixturedir, 'basic_become_cli'))

tests/unit/plugins/action/test_synchronize.py:226: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.SynchronizeTester object at 0x7fe1356c6640>
fixturepath = '/home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/unit/plugins/action/fixtures/synchronize/basic_become_cli'

    def runtest(self, fixturepath='fixtures/synchronize/basic'):
    
        metapath = os.path.join(fixturepath, 'meta.yaml')
        with open(metapath, 'rb') as f:
            fdata = f.read()
>       test_meta = yaml.load(fdata)
E       TypeError: load() missing 1 required positional argument: 'Loader'

tests/unit/plugins/action/test_synchronize.py:128: TypeError
___________________ TestSynchronizeAction.test_basic_vagrant ___________________
[gw0] linux -- Python 3.8.0 /tmp/python-55ij_ymk-ansible/python
self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.TestSynchronizeAction testMethod=test_basic_vagrant>

    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
    def test_basic_vagrant(self):
        # simple vagrant example
        x = SynchronizeTester()
>       x.runtest(fixturepath=os.path.join(self.fixturedir, 'basic_vagrant'))

tests/unit/plugins/action/test_synchronize.py:232: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.SynchronizeTester object at 0x7fe1356c6790>
fixturepath = '/home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant'

    def runtest(self, fixturepath='fixtures/synchronize/basic'):
    
        metapath = os.path.join(fixturepath, 'meta.yaml')
        with open(metapath, 'rb') as f:
            fdata = f.read()
>       test_meta = yaml.load(fdata)
E       TypeError: load() missing 1 required positional argument: 'Loader'

tests/unit/plugins/action/test_synchronize.py:128: TypeError
_____________ TestSynchronizeAction.test_basic_vagrant_become_cli ______________
[gw0] linux -- Python 3.8.0 /tmp/python-55ij_ymk-ansible/python
self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.TestSynchronizeAction testMethod=test_basic_vagrant_become_cli>

    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
    def test_basic_vagrant_become_cli(self):
        # vagrant plus sudo
        x = SynchronizeTester()
>       x.runtest(fixturepath=os.path.join(self.fixturedir, 'basic_vagrant_become_cli'))

tests/unit/plugins/action/test_synchronize.py:244: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.SynchronizeTester object at 0x7fe1356c6610>
fixturepath = '/home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_become_cli'

    def runtest(self, fixturepath='fixtures/synchronize/basic'):
    
        metapath = os.path.join(fixturepath, 'meta.yaml')
        with open(metapath, 'rb') as f:
            fdata = f.read()
>       test_meta = yaml.load(fdata)
E       TypeError: load() missing 1 required positional argument: 'Loader'

tests/unit/plugins/action/test_synchronize.py:128: TypeError
________________ TestSynchronizeAction.test_basic_vagrant_sudo _________________
[gw0] linux -- Python 3.8.0 /tmp/python-55ij_ymk-ansible/python
self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.TestSynchronizeAction testMethod=test_basic_vagrant_sudo>

    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
    def test_basic_vagrant_sudo(self):
        # vagrant plus sudo
        x = SynchronizeTester()
>       x.runtest(fixturepath=os.path.join(self.fixturedir, 'basic_vagrant_sudo'))

tests/unit/plugins/action/test_synchronize.py:238: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.SynchronizeTester object at 0x7fe1356c69a0>
fixturepath = '/home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_sudo'

    def runtest(self, fixturepath='fixtures/synchronize/basic'):
    
        metapath = os.path.join(fixturepath, 'meta.yaml')
        with open(metapath, 'rb') as f:
            fdata = f.read()
>       test_meta = yaml.load(fdata)
E       TypeError: load() missing 1 required positional argument: 'Loader'

tests/unit/plugins/action/test_synchronize.py:128: TypeError
______________ TestSynchronizeAction.test_basic_with_private_key _______________
[gw0] linux -- Python 3.8.0 /tmp/python-55ij_ymk-ansible/python
self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.TestSynchronizeAction testMethod=test_basic_with_private_key>

    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
    def test_basic_with_private_key(self):
        x = SynchronizeTester()
>       x.runtest(fixturepath=os.path.join(self.fixturedir, 'basic_with_private_key'))

tests/unit/plugins/action/test_synchronize.py:261: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.SynchronizeTester object at 0x7fe1356c6ac0>
fixturepath = '/home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key'

    def runtest(self, fixturepath='fixtures/synchronize/basic'):
    
        metapath = os.path.join(fixturepath, 'meta.yaml')
        with open(metapath, 'rb') as f:
            fdata = f.read()
>       test_meta = yaml.load(fdata)
E       TypeError: load() missing 1 required positional argument: 'Loader'

tests/unit/plugins/action/test_synchronize.py:128: TypeError
__________________ TestSynchronizeAction.test_delegate_remote __________________
[gw0] linux -- Python 3.8.0 /tmp/python-55ij_ymk-ansible/python
self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.TestSynchronizeAction testMethod=test_delegate_remote>

    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
    def test_delegate_remote(self):
        # delegate to other remote host
        x = SynchronizeTester()
>       x.runtest(fixturepath=os.path.join(self.fixturedir, 'delegate_remote'))

tests/unit/plugins/action/test_synchronize.py:250: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.SynchronizeTester object at 0x7fe1356c68e0>
fixturepath = '/home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/unit/plugins/action/fixtures/synchronize/delegate_remote'

    def runtest(self, fixturepath='fixtures/synchronize/basic'):
    
        metapath = os.path.join(fixturepath, 'meta.yaml')
        with open(metapath, 'rb') as f:
            fdata = f.read()
>       test_meta = yaml.load(fdata)
E       TypeError: load() missing 1 required positional argument: 'Loader'

tests/unit/plugins/action/test_synchronize.py:128: TypeError
_____ TestSynchronizeAction.test_delegate_remote_play_context_private_key ______
[gw0] linux -- Python 3.8.0 /tmp/python-55ij_ymk-ansible/python
self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.TestSynchronizeAction testMethod=test_delegate_remote_play_context_private_key>

    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
    def test_delegate_remote_play_context_private_key(self):
        # delegate to other remote host and use the play context private_key
        x = SynchronizeTester()
>       x.runtest(fixturepath=os.path.join(self.fixturedir, 'delegate_remote_play_context_private_key'))

tests/unit/plugins/action/test_synchronize.py:273: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.SynchronizeTester object at 0x7fe1356c6a60>
fixturepath = '/home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_play_context_private_key'

    def runtest(self, fixturepath='fixtures/synchronize/basic'):
    
        metapath = os.path.join(fixturepath, 'meta.yaml')
        with open(metapath, 'rb') as f:
            fdata = f.read()
>       test_meta = yaml.load(fdata)
E       TypeError: load() missing 1 required positional argument: 'Loader'

tests/unit/plugins/action/test_synchronize.py:128: TypeError
________________ TestSynchronizeAction.test_delegate_remote_su _________________
[gw0] linux -- Python 3.8.0 /tmp/python-55ij_ymk-ansible/python
self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.TestSynchronizeAction testMethod=test_delegate_remote_su>

    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
    def test_delegate_remote_su(self):
        # delegate to other remote host with su enabled
        x = SynchronizeTester()
>       x.runtest(fixturepath=os.path.join(self.fixturedir, 'delegate_remote_su'))

tests/unit/plugins/action/test_synchronize.py:256: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.SynchronizeTester object at 0x7fe1356c69d0>
fixturepath = '/home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_su'

    def runtest(self, fixturepath='fixtures/synchronize/basic'):
    
        metapath = os.path.join(fixturepath, 'meta.yaml')
        with open(metapath, 'rb') as f:
            fdata = f.read()
>       test_meta = yaml.load(fdata)
E       TypeError: load() missing 1 required positional argument: 'Loader'

tests/unit/plugins/action/test_synchronize.py:128: TypeError
_________ TestSynchronizeAction.test_delegate_remote_with_private_key __________
[gw0] linux -- Python 3.8.0 /tmp/python-55ij_ymk-ansible/python
self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.TestSynchronizeAction testMethod=test_delegate_remote_with_private_key>

    @patch('ansible_collections.ansible.posix.plugins.action.synchronize.connection_loader', FakePluginLoader)
    def test_delegate_remote_with_private_key(self):
        # delegate to other remote host and use the module param private_key
        x = SynchronizeTester()
>       x.runtest(fixturepath=os.path.join(self.fixturedir, 'delegate_remote_with_private_key'))

tests/unit/plugins/action/test_synchronize.py:267: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <ansible_collections.ansible.posix.tests.unit.plugins.action.test_synchronize.SynchronizeTester object at 0x7fe1356c6cd0>
fixturepath = '/home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/unit/plugins/action/fixtures/synchronize/delegate_remote_with_private_key'
    def runtest(self, fixturepath='fixtures/synchronize/basic'):
    
        metapath = os.path.join(fixturepath, 'meta.yaml')
        with open(metapath, 'rb') as f:
            fdata = f.read()
>       test_meta = yaml.load(fdata)
E       TypeError: load() missing 1 required positional argument: 'Loader'

tests/unit/plugins/action/test_synchronize.py:128: TypeError
=============================== warnings summary ===============================
../../../../../venv/lib/python3.8/site-packages/_pytest/config/__init__.py:1233
../../../../../venv/lib/python3.8/site-packages/_pytest/config/__init__.py:1233
  /home/zuul/venv/lib/python3.8/site-packages/_pytest/config/__init__.py:1233: PytestConfigWarning: Unknown config option: mock_use_standalone_module
  
    self._warn_or_fail_if_strict(f"Unknown config option: {key}\n")

../../../../../venv/lib/python3.8/site-packages/_yaml/__init__.py:18
  /home/zuul/venv/lib/python3.8/site-packages/_yaml/__init__.py:18: DeprecationWarning: The _yaml extension module is now located at yaml._yaml and its location is subject to change.  To use the LibYAML-based parser and emitter, import from `yaml`: `from yaml import CLoader as Loader, CDumper as Dumper`.
    warnings.warn(

../../../../../venv/lib/python3.8/distutils/__init__.py:4
  /home/zuul/venv/lib/python3.8/distutils/__init__.py:4: DeprecationWarning: the imp module is deprecated in favour of importlib; see the module's documentation for alternative uses
    import imp

-- Docs: https://docs.pytest.org/en/stable/warnings.html
- generated xml file: /home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/output/junit/python3.8-units.xml -
=========================== short test summary info ============================
FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic
FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_become
FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_become_cli
FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_vagrant
FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_vagrant_become_cli
FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_vagrant_sudo
FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_basic_with_private_key
FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote
FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote_play_context_private_key
FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote_su
FAILED tests/unit/plugins/action/test_synchronize.py::TestSynchronizeAction::test_delegate_remote_with_private_key
=================== 11 failed, 3 passed, 4 warnings in 1.32s ===================
Command exited with status 1 after 1.6836273670196533 seconds.
ERROR: Command "pytest --boxed -r a -n auto --color no -p no:cacheprovider -c /home/zuul/venv/lib/python3.8/site-packages/ansible_test/_data/pytest.ini --junit-xml /home/zuul/.ansible/collections/ansible_collections/ansible/posix/tests/output/junit/python3.8-units.xml --strict-markers -vvvv tests/unit/modules/system/test_mount.py tests/unit/plugins/action/test_synchronize.py" returned exit status 1.
Cleaning up temporary python directory: /tmp/python-55ij_ymk-ansible
```
