### PR TITLE
Remove deprecated option from nfs mount example

### DIFF
--- a/changelogs/fragments/288_mounts_options.yml
+++ b/changelogs/fragments/288_mounts_options.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- mount - remove deprecated option from nfs example

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -172,7 +172,7 @@ EXAMPLES = r'''
   ansible.posix.mount:
     src: 192.168.1.100:/nfs/ssd/shared_data
     path: /mnt/shared_data
-    opts: rw,sync,hard,intr
+    opts: rw,sync,hard
     state: mounted
     fstype: nfs
 
@@ -180,7 +180,7 @@ EXAMPLES = r'''
   ansible.posix.mount:
     src: 192.168.1.100:/nfs/ssd/shared_data
     path: /mnt/shared_data
-    opts: rw,sync,hard,intr
+    opts: rw,sync,hard
     boot: no
     state: mounted
     fstype: nfs


### PR DESCRIPTION
##### SUMMARY
This removes the `intr` option from the documentation example for nfs mounts.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
mount.py

##### ADDITIONAL INFORMATION
According to the nfs [manpage](https://linux.die.net/man/5/nfs) the `intr/ nointr` option has been deprecated with Kernel 2.6.25 which was released in April 2008 [wiki](https://en.wikipedia.org/wiki/Linux_kernel_version_history)

Even RHEL 6.10 which is already on Extended life cycle support is using a newer 2.6 Kernel. https://access.redhat.com/articles/3078

This does not change any module functionality. It simply removes the option from the nfs mount example.
