### PR TITLE
[CI] Replace Fedora 33 with Fedora 35 for devel tests 

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -53,10 +53,10 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 33
-              test: fedora33
             - name: Fedora 34
               test: fedora34
+            - name: Fedora 35
+              test: fedora35
             - name: openSUSE 15 py3
               test: opensuse15
             - name: Ubuntu 18.04


### PR DESCRIPTION
##### SUMMARY
Replace Fedora 33 with Fedora 35 for devel tests 

- Relates to https://github.com/ansible-collections/overview/issues/45#issuecomment-963553255

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
- azure-pipelines/azure-pipelines.yml

##### ADDITIONAL INFORMATION
None