### PR TITLE
Add RHEL8 library python3-libsemanage

### DIFF
--- a/changelogs/fragments/299_seboolean_python3.yml
+++ b/changelogs/fragments/299_seboolean_python3.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- seboolean - add ``python3-libsemanage`` package dependency for RHEL8+ systems.

--- a/plugins/modules/seboolean.py
+++ b/plugins/modules/seboolean.py
@@ -40,6 +40,7 @@ notes:
 requirements:
 - libselinux-python
 - libsemanage-python
+- python3-libsemanage
 author:
 - Stephen Fromm (@sfromm)
 '''
@@ -284,7 +285,7 @@ def main():
         module.fail_json(msg=missing_required_lib('libselinux-python'), exception=SELINUX_IMP_ERR)
 
     if not HAVE_SEMANAGE:
-        module.fail_json(msg=missing_required_lib('libsemanage-python'), exception=SEMANAGE_IMP_ERR)
+        module.fail_json(msg=missing_required_lib('libsemanage-python or python3-libsemanage'), exception=SEMANAGE_IMP_ERR)
 
     ignore_selinux_state = module.params['ignore_selinux_state']
 


### PR DESCRIPTION
##### SUMMARY
In modern systems (RHEL8+) with python3 default, the library requirement is `python3-libsemanage`.
Updated `libsemanage-python` to `python3-libsemanage`.
- Fixes `RHEL8 python3 support`

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/seboolean.py

##### ADDITIONAL INFORMATION

```paste below
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ModuleNotFoundError: No module named 'semanage'
fatal: [demo.example.com]: FAILED! => {"changed": false, "msg": "Failed to import the required Python library (libsemanage-python) on demo.example.com's Python /usr/libexec/platform-python. Please read the module documentation and install it in the appropriate location. If the required library is installed, but Ansible is using the wrong Python interpreter, please consult the documentation on ansible_python_interpreter"}

# dnf search libsemanage
Updating Subscription Management repositories.
Last metadata expiration check: 0:33:20 ago on Fri 17 Dec 2021 11:38:51 AM UTC.
================================ Name Exactly Matched: libsemanage ================================
libsemanage.x86_64 : SELinux binary policy manipulation library
libsemanage.i686 : SELinux binary policy manipulation library
=============================== Name & Summary Matched: libsemanage ===============================
python3-libsemanage.x86_64 : semanage python 3 bindings for libsemanage
```
