### PR TITLE
[CI] Fix exit code in CI entrypoint to address shellckeck issue

### DIFF
--- a/changelogs/fragments/302_shippable_exit_code.yml
+++ b/changelogs/fragments/302_shippable_exit_code.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- CI tests - fix exit code to address shellckeck test issue (https://github.com/ansible-collections/ansible.posix/issues/301).

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -50,7 +50,7 @@ function retry
         echo "@* -> ${result}"
     done
     echo "Command '@*' failed 3 times!"
-    exit -1
+    exit 255
 }
 
 command -v pip


### PR DESCRIPTION
##### SUMMARY
Fix wrong exit code -1 in CI entrypoint to address shellcheck failure:

- Fixes #301

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
- tests/utils/shippable/shippable.sh

##### ADDITIONAL INFORMATION
None
