### PR TITLE
[WIP] Added handling ansible_ssh_host the same as ansible_host

### DIFF
--- a/changelogs/fragments/316_ansible_ssh_host_handling.yml
+++ b/changelogs/fragments/316_ansible_ssh_host_handling.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- synchronize - handle ansible_ssh_host the same as ansible_host (https://github.com/ansible-collections/ansible.posix/issues/298).

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -235,10 +235,11 @@ class ActionModule(ActionBase):
         src_host = '127.0.0.1'
         inventory_hostname = task_vars.get('inventory_hostname')
         dest_host_inventory_vars = task_vars['hostvars'].get(inventory_hostname)
-        dest_host = dest_host_inventory_vars.get('ansible_host', inventory_hostname)
-
+        dest_host = dest_host_inventory_vars.get('ansible_host') or \
+            dest_host_inventory_vars.get('ansible_ssh_host', inventory_hostname)
         dest_host_ids = [hostid for hostid in (dest_host_inventory_vars.get('inventory_hostname'),
-                                               dest_host_inventory_vars.get('ansible_host'))
+                                               dest_host_inventory_vars.get('ansible_host'),
+                                               dest_host_inventory_vars.get('ansible_ssh_host'))
                          if hostid is not None]
 
         localhost_ports = set()


### PR DESCRIPTION
##### SUMMARY
Currently, synchronize action plugin only handle `ansible_host` or `inventory_host` as a remote dest.
`ansible_ssh_host` will be deprecated, but it is still available in the current ansible-core devel version. Therefore, it should be handled in the same as `ansible_host`.

- Fixes #298

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.posix.synchronize

##### ADDITIONAL INFORMATION
```
None
```