### PR TITLE
Update AZP matrix to replace RHEL7.6 with 7.9

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -233,8 +233,8 @@ stages:
           targets:
             - name: OS X 10.11
               test: osx/10.11
-            - name: RHEL 7.6
-              test: rhel/7.6
+            - name: RHEL 7.9
+              test: rhel/7.9
             - name: RHEL 8.2
               test: rhel/8.2
             - name: FreeBSD 11.1
@@ -252,8 +252,8 @@ stages:
           targets:
             - name: OS X 10.11
               test: osx/10.11
-            - name: RHEL 7.6
-              test: rhel/7.6
+            - name: RHEL 7.9
+              test: rhel/7.9
             - name: RHEL 8.1
               test: rhel/8.1
             - name: FreeBSD 11.1


### PR DESCRIPTION
##### SUMMARY

Update AZP matrix to replace RHEL7.6 with RHEL7.9 for the following test environments:

- Remote 2.9
- Remote 2.10

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
Trying to address the following CI issue on RHEL7.6 test environment:
```
02:11 https://rhui3.us-east-1.aws.ce.redhat.com/pulp/content/rhui-client-config/rhel/server/7/x86_64/os/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
02:11 Trying other mirror.
02:11 To address this issue please refer to the below knowledge base article 
02:11 
02:11         compromise:
02:11 
02:11             yum-config-manager --save --setopt=rhui-REGION-client-config-server-7.skip_if_unavailable=true
02:11 
02:11 failure: repodata/repomd.xml from rhui-REGION-client-config-server-7: [Errno 256] No more mirrors to try.
02:11 https://rhui3.us-east-1.aws.ce.redhat.com/pulp/content/rhui-client-config/rhel/server/7/x86_64/os/repodata/repomd.xml: [Errno 14] HTTPS Error 404 - Not Found
02:11 Failed to install packages. Sleeping before trying again...
02:21 
02:21 
02:21 Could not contact any CDS load balancers: https://rhui3.us-east-1.aws.ce.redhat.com/pulp/content/.
02:21 Failed to install packages. Sleeping before trying again...
02:31 
```