### PR TITLE
firewalld: Add support for configuring intra zone forwarding

### DIFF
--- a/changelogs/fragments/320_firewalld_intra_zone_forwarding.yml
+++ b/changelogs/fragments/320_firewalld_intra_zone_forwarding.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+- firewalld - Added parameter ``forward`` to support enabling/disabling intra-zone 
+  forwarding.

--- a/docs/ansible.posix.firewalld_module.rst
+++ b/docs/ansible.posix.firewalld_module.rst
@@ -120,6 +120,21 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>forward</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>Whether intra zone forwarding should be enabled/disabled for a zone in firewalld.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>offline</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -450,6 +465,12 @@ Examples
 
     - ansible.posix.firewalld:
         masquerade: yes
+        state: enabled
+        permanent: yes
+        zone: dmz
+
+    - ansible.posix.firewalld:
+        forward: yes
         state: enabled
         permanent: yes
         zone: dmz

--- a/plugins/module_utils/firewalld.py
+++ b/plugins/module_utils/firewalld.py
@@ -126,9 +126,16 @@ class FirewallTransaction(object):
     def get_fw_zone_settings(self):
         if self.fw_offline:
             fw_zone = self.fw.config.get_zone(self.zone)
-            fw_settings = FirewallClientZoneSettings(
-                list(self.fw.config.get_zone_config(fw_zone))
-            )
+
+            # If firewalld version is 0.9.0 or higher retrieve the configuration
+            # using the get_zone_config_dict call, otherwise the returned value
+            # for the 'forward' field is always zero.
+            if LooseVersion(FW_VERSION) >= LooseVersion("0.9.0"):
+                fw_settings = FirewallClientZoneSettings(self.fw.config.get_zone_config_dict(fw_zone))
+            else:
+                fw_settings = FirewallClientZoneSettings(
+                    list(self.fw.config.get_zone_config(fw_zone))
+                )
         else:
             fw_zone = self.fw.config().getZoneByName(self.zone)
             fw_settings = fw_zone.getSettings()

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -109,6 +109,7 @@ options:
   forward:
     description:
       - Whether intra zone forwarding should be enabled/disabled for a zone in firewalld.
+        This parameter supports on python-firewall 0.9.0 or later.
     type: bool
   offline:
     description:
@@ -191,7 +192,7 @@ EXAMPLES = r'''
     forward: yes
     state: enabled
     permanent: yes
-    zone: dmz
+    zone: custom
 
 - ansible.posix.firewalld:
     zone: custom
@@ -228,10 +229,12 @@ EXAMPLES = r'''
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible_collections.ansible.posix.plugins.module_utils.firewalld import FirewallTransaction, fw_offline
+from ansible_collections.ansible.posix.plugins.module_utils.version import StrictVersion
 
 try:
     from firewall.client import Rich_Rule
     from firewall.client import FirewallClientZoneSettings
+    from firewall.config import VERSION as FIREWALLD_VERSION
 except ImportError:
     # The import errors are handled via FirewallTransaction, don't need to
     # duplicate that here
@@ -1050,6 +1053,9 @@ def main():
                         'To avoid unexpected behavior, please change the value to boolean.' % masquerade)
 
     if forward is not None:
+
+        if StrictVersion(FIREWALLD_VERSION) < StrictVersion('0.9.0'):
+            module.fail_json(msg=f'Intra zone forwarding requires firewalld>=0.9.0. Current version is {FIREWALLD_VERSION}.')
 
         transaction = ForwardTransaction(
             module,

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -1055,7 +1055,7 @@ def main():
     if forward is not None:
 
         if StrictVersion(FIREWALLD_VERSION) < StrictVersion('0.9.0'):
-            module.fail_json(msg=f'Intra zone forwarding requires firewalld>=0.9.0. Current version is {FIREWALLD_VERSION}.')
+            module.fail_json(msg='Intra zone forwarding requires firewalld>=0.9.0. Current version is {0}.'.format(FIREWALLD_VERSION))
 
         transaction = ForwardTransaction(
             module,

--- a/tests/integration/targets/firewalld/tasks/forward_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/forward_test_cases.yml
@@ -2,50 +2,85 @@
 # (c) 2017, Adam Miller <admiller@redhat.com>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-- name: firewalld forward test permanent enabled
-  firewalld:
-    forward: yes
-    permanent: true
-    state: enabled
-  register: result
+- name: query firewalld version
+  package_facts:
 
-- name: assert firewalld forward test permanent enabled worked
-  assert:
-    that:
-    - result is changed
+- name: run tests if intra zone forwarding is supported
+  block:
 
-- name: firewalld forward test permanent enabled rerun (verify not changed)
-  firewalld:
-    forward: yes
-    permanent: true
-    state: enabled
-  register: result
+  # Starting with firewalld 1.0.0 intra-zone forwarding is enabled by default.
+  # Ensure it is disabled before starting our tests.
+  - name: ensure forwarding starts disabled
+    firewalld:
+      forward: yes
+      permanent: true
+      state: disabled
 
-- name: assert firewalld forward test permanent enabled rerun worked (verify not changed)
-  assert:
-    that:
-    - result is not changed
+  - name: firewalld forward test permanent enabled
+    firewalld:
+      forward: yes
+      permanent: true
+      state: enabled
+    register: result
 
-- name: firewalld forward test permanent disabled
-  firewalld:
-    forward: no
-    permanent: true
-    state: disabled
-  register: result
+  - name: assert firewalld forward test permanent enabled worked
+    assert:
+      that:
+      - result is changed
 
-- name: assert firewalld forward test permanent disabled worked
-  assert:
-    that:
-    - result is changed
+  - name: firewalld forward test permanent enabled rerun (verify not changed)
+    firewalld:
+      forward: yes
+      permanent: true
+      state: enabled
+    register: result
 
-- name: firewalld forward test permanent disabled rerun (verify not changed)
-  firewalld:
-    forward: no
-    permanent: true
-    state: disabled
-  register: result
+  - name: assert firewalld forward test permanent enabled rerun worked (verify not changed)
+    assert:
+      that:
+      - result is not changed
 
-- name: assert firewalld forward test permanent disabled rerun worked (verify not changed)
-  assert:
-    that:
-    - result is not changed
+  - name: firewalld forward test permanent disabled
+    firewalld:
+      forward: no
+      permanent: true
+      state: disabled
+    register: result
+
+  - name: assert firewalld forward test permanent disabled worked
+    assert:
+      that:
+      - result is changed
+
+  - name: firewalld forward test permanent disabled rerun (verify not changed)
+    firewalld:
+      forward: no
+      permanent: true
+      state: disabled
+    register: result
+
+  - name: assert firewalld forward test permanent disabled rerun worked (verify not changed)
+    assert:
+      that:
+      - result is not changed
+
+  when: ansible_facts.packages.firewalld[0].version is version('0.9.0', '>=')
+
+- name: run tests if intra zone forwarding is not supported
+  block:
+
+  - name: try to enable intra zone forwarding
+    firewalld:
+      forward: yes
+      permanent: yes
+      state: enabled
+    ignore_errors: yes
+    register: result
+
+  - name: assert unsupported firewalld version
+    assert:
+      that:
+      - result is failed
+      - "'Intra zone forwarding requires firewalld>=0.9.0. Current version is' in result.msg"
+
+  when: ansible_facts.packages.firewalld[0].version is version('0.9.0', '<')

--- a/tests/integration/targets/firewalld/tasks/forward_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/forward_test_cases.yml
@@ -1,0 +1,51 @@
+# Test playbook for the firewalld module - forward operations
+# (c) 2017, Adam Miller <admiller@redhat.com>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: firewalld forward test permanent enabled
+  firewalld:
+    forward: yes
+    permanent: true
+    state: enabled
+  register: result
+
+- name: assert firewalld forward test permanent enabled worked
+  assert:
+    that:
+    - result is changed
+
+- name: firewalld forward test permanent enabled rerun (verify not changed)
+  firewalld:
+    forward: yes
+    permanent: true
+    state: enabled
+  register: result
+
+- name: assert firewalld forward test permanent enabled rerun worked (verify not changed)
+  assert:
+    that:
+    - result is not changed
+
+- name: firewalld forward test permanent disabled
+  firewalld:
+    forward: no
+    permanent: true
+    state: disabled
+  register: result
+
+- name: assert firewalld forward test permanent disabled worked
+  assert:
+    that:
+    - result is changed
+
+- name: firewalld forward test permanent disabled rerun (verify not changed)
+  firewalld:
+    forward: no
+    permanent: true
+    state: disabled
+  register: result
+
+- name: assert firewalld forward test permanent disabled rerun worked (verify not changed)
+  assert:
+    that:
+    - result is not changed

--- a/tests/integration/targets/firewalld/tasks/run_all_tests.yml
+++ b/tests/integration/targets/firewalld/tasks/run_all_tests.yml
@@ -21,3 +21,6 @@
 
 # firewalld port forwarding operation test cases
 - include_tasks: port_forward_test_cases.yml
+
+# firewalld zone forwarding operation test cases
+- include_tasks: forward_test_cases.yml

--- a/tests/integration/targets/firewalld/tasks/source_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/source_test_cases.yml
@@ -82,4 +82,4 @@
   assert:
     that:
     - result is not changed
-    - "result.msg == 'parameters are mutually exclusive: icmp_block|icmp_block_inversion|service|port|port_forward|rich_rule|interface|masquerade|source|target'"
+    - "result.msg == 'parameters are mutually exclusive: icmp_block|icmp_block_inversion|service|port|port_forward|rich_rule|interface|masquerade|forward|source|target'"


### PR DESCRIPTION
##### SUMMARY
Added support for configuring [intra zone forwarding](https://firewalld.org/2020/04/intra-zone-forwarding) to the ansible.posix.firewalld module.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.posix.firewalld

##### ADDITIONAL INFORMATION
Querying whether the forwarding option is enabled/disabled is already supported by the ansible.posix.firewalld_info module, so it would be logical to be able to configure it from the ansible.posix.firewalld module as well.
