### PR TITLE
[CI] Update AZP matrix to remove CentOS8 test

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -75,8 +75,6 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 33
               test: fedora33
             - name: Fedora 34
@@ -101,8 +99,6 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 32
               test: fedora32
             - name: Fedora 33
@@ -127,8 +123,6 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 30
               test: fedora30
             - name: Fedora 31
@@ -153,8 +147,6 @@ stages:
               test: centos6
             - name: CentOS 7
               test: centos7
-            - name: CentOS 8
-              test: centos8
             - name: Fedora 30
               test: fedora30
             - name: Fedora 31


### PR DESCRIPTION
##### SUMMARY
Remove CentOS8 test from the following docker container tests:
_Note: CentOS8 container test has already been removed from the devel branch test._

- 2.12
- 2.11
- 2.10
- 2.9


Reference: ansible-collections/news-for-maintainers#3

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
ansible.posix

##### ADDITIONAL INFORMATION
None