### PR TITLE
[CI] Update AZP matrix to remove CentOS8 shippable test

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,4 +1,4 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
 
-rsync [platform:centos-8 platform:rhel-8]
+rsync [platform:rhel-8]

--- a/shippable.yml
+++ b/shippable.yml
@@ -15,7 +15,7 @@ matrix:
     - env: T=2.9/freebsd/12.0/1
     - env: T=2.9/linux/centos6/1
     - env: T=2.9/linux/centos7/1
-    - env: T=2.9/linux/centos8/1
+#    - env: T=2.9/linux/centos8/1
     - env: T=2.9/linux/fedora30/1
     - env: T=2.9/linux/fedora31/1
     - env: T=2.9/linux/opensuse15py2/1
@@ -30,7 +30,7 @@ matrix:
     - env: T=2.10/freebsd/12.1/1
     - env: T=2.10/linux/centos6/1
     - env: T=2.10/linux/centos7/1
-    - env: T=2.10/linux/centos8/1
+#    - env: T=2.10/linux/centos8/1
     - env: T=2.10/linux/fedora30/1
     - env: T=2.10/linux/fedora31/1
     - env: T=2.10/linux/opensuse15py2/1
@@ -45,7 +45,7 @@ matrix:
     - env: T=devel/freebsd/12.1/1
     - env: T=devel/linux/centos6/1
     - env: T=devel/linux/centos7/1
-    - env: T=devel/linux/centos8/1
+#    - env: T=devel/linux/centos8/1
     - env: T=devel/linux/fedora30/1
     - env: T=devel/linux/fedora31/1
     - env: T=devel/linux/opensuse15py2/1


### PR DESCRIPTION
##### SUMMARY
We are no longer using Shippable for CI tests, but it would be better to remove CentOS 8 tests from this just in case.

- shippable.yml
- bindep.txt

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
- Reference0: #321
- Reference1: https://github.com/ansible-collections/news-for-maintainers/issues/3