### PR TITLE
Fix: synchronize directories contains spaces in their paths

### DIFF
--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -430,8 +430,8 @@ def main():
         except ValueError:
             module.fail_json(msg='Could not determine controller hostname for rsync to send to')
     else:
-        source = module.params['src']
-        dest = module.params['dest']
+        source = '"' + module.params['src'] + '"'
+        dest = '"' + module.params['dest'] + '"'
     dest_port = module.params['dest_port']
     delete = module.params['delete']
     private_key = module.params['private_key']


### PR DESCRIPTION
##### SUMMARY
It's a hotfix for problem that Ansible cannot synchronize files if directories contains whitespaces in their paths. This bug there for years (at least since 2015), I thought I submitted the fix. Anyway, please review it and make my code to be more optimal for Python or Ansible code guidelines.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Synchronize