### PR TITLE
allowing `synchronize` to elevate permissions when `sudo` requires password entry - implements #334

### DIFF
--- a/changelogs/fragments/334_synchronize_using_become_pass.yml
+++ b/changelogs/fragments/334_synchronize_using_become_pass.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- synchronize - elevating privileges now works even when `sudo` requires entering the `become_pass`

--- a/docs/ansible.posix.synchronize_module.rst
+++ b/docs/ansible.posix.synchronize_module.rst
@@ -580,7 +580,7 @@ Notes
 
    - The user and permissions for the synchronize `dest` are those of the `remote_user` on the destination host or the `become_user` if `become=yes` is active.
    - In Ansible 2.0 a bug in the synchronize module made become occur on the "local host".  This was fixed in Ansible 2.0.1.
-   - Currently, synchronize is limited to elevating permissions via passwordless sudo.  This is because rsync itself is connecting to the remote machine and rsync doesn't give us a way to pass sudo credentials in.
+   - Currently, synchronize is limited to elevating permissions via sudo.  This now even works when password entry is required.
    - Currently there are only a few connection types which support synchronize (ssh, paramiko, local, and docker) because a sync strategy has been determined for those connection types.  Note that the connection for these must not need a password as rsync itself is making the connection and rsync does not provide us a way to pass a password to the connection.
    - Expect that dest=~/x will be ~<remote_user>/x even if using sudo.
    - Inspect the verbose output to validate the destination user/host/path are what was expected.


### PR DESCRIPTION
##### SUMMARY
This PR implements feature request #334, so that `ansible.posix.synchronize` will work with `become: yes` even if the ssh account is not set up for passwordless sudo.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ansible.posix.synchronize`

##### ADDITIONAL INFORMATION
Steps to reproduce:
- On the target machine, set up an account with publickey authorization that is part of the `sudo` group, but make sure it has not been set up for `NOPASSWD` in the `sudoers` configuration.
- Use `ansible.posix.synchronize` with `become: yes` and use the account described above.
- The module will fail to complete because the invocation of `sudo rsync` on the remote machine brings up a password prompt and lets `rsync` fail.

With this PR, it will no longer fail.

I've been trying to follow the community guidelines for setting up this PR, but I will need some help regarding the following topics:
- I'm not sure if I can use a hardcoded `/bin/sh` for invoking `bash` within the wrapping code that I introduce in `plugins.modules.synchronize.py`. Hope this is all correct.
- Could someone cross-check I've not broken quoting / escaping on the strings that I manipulate?
- I don't know how I can add testing for this feature or actually test if my changes break anything. The repository seems to fail tests on github already.

Thanks in advance ;-)