### PR TITLE
Add testing against ansible-core 2.13

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -63,6 +63,26 @@ stages:
               test: ubuntu1804
             - name: Ubuntu 20.04
               test: ubuntu2004
+  - stage: Docker_2_13
+    displayName: Docker 2.13
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.13/linux/{0}/1
+          targets:
+            - name: CentOS 7
+              test: centos7
+            - name: Fedora 34
+              test: fedora34
+            - name: Fedora 35
+              test: fedora35
+            - name: openSUSE 15 py3
+              test: opensuse15
+            - name: Ubuntu 18.04
+              test: ubuntu1804
+            - name: Ubuntu 20.04
+              test: ubuntu2004
   - stage: Docker_2_12
     displayName: Docker 2.12
     dependsOn: []
@@ -179,6 +199,24 @@ stages:
               test: freebsd/12.3
             - name: FreeBSD 13.0
               test: freebsd/13.0
+  - stage: Remote_2_13
+    displayName: Remote 2.13
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.13/{0}/1
+          targets:
+            - name: MacOS 12.0
+              test: macos/12.0
+            - name: RHEL 7.9
+              test: rhel/7.9
+            - name: RHEL 8.5
+              test: rhel/8.5
+            - name: FreeBSD 12.3
+              test: freebsd/12.3
+            - name: FreeBSD 13.0
+              test: freebsd/13.0
   - stage: Remote_2_12
     displayName: Remote 2.12
     dependsOn: []
@@ -265,6 +303,8 @@ stages:
       - Docker_2_11
       - Remote_2_12
       - Docker_2_12
+      - Remote_2_13
+      - Docker_2_13
       - Remote_devel
       - Docker_devel
     jobs:

--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ None
 
 <!-- List the versions of Ansible the collection has been tested with. Must match what is in galaxy.yml. -->
 
-* ansible-core 2.13 (devel)
+* ansible-core 2.14 (devel)
+- ansible-core 2.13 (stable)
 * ansible-core 2.12 (stable)
 * ansible-core 2.11 (stable)
 * ansible-base 2.10 (stable)

--- a/changelogs/fragments/347_add_branch_213.yml
+++ b/changelogs/fragments/347_add_branch_213.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- CI tests - add CI tests against stable-2.13 (https://github.com/ansible-collections/ansible.posix/issues/345).


### PR DESCRIPTION
##### SUMMARY

As a part of the issue https://github.com/ansible-collections/ansible.posix/issues/345, it addresses CI tests for stable-2.13.

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
None
