### PR TITLE
[CI] Added check_mode attr to synchronize plugin unit test

### DIFF
--- a/changelogs/fragments/353_ci_fix_unittest_for_synchronize.yml
+++ b/changelogs/fragments/353_ci_fix_unittest_for_synchronize.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- CI tests - added check_mode attribute to TaskMock class for synchronize plugin unit test (https://github.com/ansible-collections/ansible.posix/issues/352).

--- a/tests/unit/plugins/action/test_synchronize.py
+++ b/tests/unit/plugins/action/test_synchronize.py
@@ -55,6 +55,7 @@ class TaskMock(object):
     become = None
     become_user = None
     become_method = None
+    check_mode = False
 
 
 class StdinMock(object):


### PR DESCRIPTION
##### SUMMARY

Added check_mode attr to synchronize plugin unit test:

* Added check_mode attribute to TaskMock class in the unit test for
  synchronize plugin
* Fixes #352

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
- ansible.posix.tests.unit