### PR TITLE
maintain proper formating of the remote paths when defined as user@ho…

### DIFF
--- a/changelogs/fragments/361_maintain_proper_formating_remote_paths.yml
+++ b/changelogs/fragments/361_maintain_proper_formating_remote_paths.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- synchronize - maintain proper formatting of the remote paths (https://github.com/ansible-collections/ansible.posix/pull/361).

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -77,7 +77,14 @@ class ActionModule(ActionBase):
 
         if self._host_is_ipv6_address(host):
             return '[%s%s]:%s' % (user_prefix, host, path)
-        return '%s%s:%s' % (user_prefix, host, path)
+
+        # preserve formatting of remote paths if host or user@host is explicitly defined in the path
+        if ':' not in path:
+            return '%s%s:%s' % (user_prefix, host, path)
+        elif '@' not in path:
+            return '%s%s' % (user_prefix, path)
+        else:
+            return path
 
     def _process_origin(self, host, path, user):
 


### PR DESCRIPTION
…st:/... or host:/...

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

update  _format_rsync_rsh_target for proper handling of remote rsh/ssh paths.  fixes #360

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

ansible.posix.synchronize

