### PR TITLE
mount: remove boot exception if defaults in opts

### DIFF
--- a/changelogs/fragments/365-boot-linux.yml
+++ b/changelogs/fragments/365-boot-linux.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - mount - Handle ``boot`` option on Linux, NetBSD and OpenBSD correctly (https://github.com/ansible-collections/ansible.posix/issues/364).

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -850,11 +850,8 @@ def main():
             args['warnings'].append("Ignore the 'boot' due to 'opts' contains 'noauto'.")
         elif not module.params['boot']:
             args['boot'] = 'no'
-            if 'defaults' in opts:
-                args['warnings'].append("Ignore the 'boot' due to 'opts' contains 'defaults'.")
-            else:
-                opts.append('noauto')
-                args['opts'] = ','.join(opts)
+            opts.append('noauto')
+            args['opts'] = ','.join(opts)
 
     # If fstab file does not exist, we first need to create it. This mainly
     # happens when fstab option is passed to the module.

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -472,6 +472,25 @@
         path: /tmp/myfs
         state: absent
 
+    - name: Mount the FS with noauto option and defaults
+      ansible.posix.mount:
+        path: /tmp/myfs
+        src: /tmp/myfs.img
+        fstype: ext3
+        state: mounted
+        boot: false
+      register: mount_info
+
+    - name: Assert the mount without noauto was successful
+      ansible.builtin.assert:
+        that:
+          - "'noauto' in mount_info['opts'].split(',')"
+
+    - name: Unmount FS
+      ansible.posix.mount:
+        path: /tmp/myfs
+        state: absent
+
     - name: Remove the test FS
       ansible.builtin.file:
         path: '{{ item }}'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
There is no need for an exception on `defaults` option when adding `noauto`. Mount is implemented as last win.
from mount(8):
```
       If you want to override mount options from /etc/fstab, you have to use the -o option:

          mount device|dir -o options

       and then the mount options from the command line will be appended to the list of options from /etc/fstab. This default behaviour can be changed using the --options-mode command-line option. The usual behavior is that the last
       option wins if there are conflicting ones.
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #364
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- ansible.posix.mount
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
