### PR TITLE
[CI] Bump AZP container version

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -36,7 +36,7 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:1.9.0
+      image: quay.io/ansible/azure-pipelines-test-container:3.0.0
 
 pool: Standard
 

--- a/changelogs/fragments/375_update_azp_container.yml
+++ b/changelogs/fragments/375_update_azp_container.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - CI - AZP test container to 3.0.0 (https://github.com/ansible-collections/news-for-maintainers/issues/18).


### PR DESCRIPTION
##### SUMMARY
Addresses the following requirements:

- https://github.com/ansible-collections/news-for-maintainers/issues/18

However, ansible.posix needs to support Ansible Engine 2.9, so we will keep 2.9, 2.10, and 2.11 in the CI tests for now.

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
None