### PR TITLE
[CI] Update AZP matrix to remove Fedora35 and FreeBSD12.3 tests from devel

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -53,8 +53,6 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 35
-              test: fedora35
             - name: Fedora 36
               test: fedora36
             - name: openSUSE 15 py3
@@ -197,8 +195,6 @@ stages:
               test: rhel/8.6
             - name: RHEL 9.0
               test: rhel/9.0
-            - name: FreeBSD 12.3
-              test: freebsd/12.3
             - name: FreeBSD 13.1
               test: freebsd/13.1
   - stage: Remote_2_13


### PR DESCRIPTION
##### SUMMARY
Removing Fedora35 and FreeBSD12.3 from CI tests for devel branch(docker and remote).

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
- Related to ansible-collections/news-for-maintainers/issues/21