### PR TITLE
[CI] Address pylint check check error in ansible-test-sanity-docker-devel test

### DIFF
--- a/changelogs/fragments/386_follow_ci_testing_rules.yml
+++ b/changelogs/fragments/386_follow_ci_testing_rules.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - CI - following the new CI testing rule ansible-test-sanity-docker-devel.

--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -347,6 +347,8 @@ def keyfile(module, user, write=False, path=None, manage_dir=True, follow=False)
         basedir = os.path.dirname(keysfile)
         if not os.path.exists(basedir):
             os.makedirs(basedir)
+
+        f = None
         try:
             f = open(keysfile, "w")  # touches file so we can set ownership and perms
         finally:

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -226,7 +226,7 @@ def _escape_fstab(v):
     if isinstance(v, int):
         return v
     else:
-        return(
+        return (
             v.
             replace('\\', '\\134').
             replace(' ', '\\040').

--- a/tests/integration/targets/authorized_key/tasks/setup_steps.yml
+++ b/tests/integration/targets/authorized_key/tasks/setup_steps.yml
@@ -1,5 +1,14 @@
 # -------------------------------------------------------------
 # Setup steps
+- name: Clean up the working directory and files
+  file:
+    path: '{{ output_dir }}'
+    state: absent
+
+- name: Create the working directory
+  file:
+    path: '{{ output_dir }}'
+    state: directory
 
 - name: copy an existing file in place with comments
   copy:


### PR DESCRIPTION
##### SUMMARY
Currently, ansible-test-sanity-docker-devel is set `non voting`, but we need to fix pylint check error in several modules.

- https://ansible.softwarefactory-project.io/zuul/build/fbd5ac593fe44fa7b3d77e5557de1607

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- [x] ansible.posix.authorized_keys
- [x] ansible.posix.mount

##### ADDITIONAL INFORMATION
None