### PR TITLE
Fix callback output to align header with roles, tasks and play RECAP

### DIFF
--- a/changelogs/fragments/387_callback_output_header.yml
+++ b/changelogs/fragments/387_callback_output_header.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - callback plugins - Add recap information to timer, profile_roles and profile_tasks callback outputs (https://github.com/ansible-collections/ansible.posix/pull/387).

--- a/plugins/callback/profile_roles.py
+++ b/plugins/callback/profile_roles.py
@@ -128,7 +128,10 @@ class CallbackModule(CallbackBase):
         self._display_tasktime()
 
     def playbook_on_stats(self, stats):
-        self._display_tasktime()
+        # Align summary report header with other callback plugin summary
+        self._display.banner("ROLES RECAP")
+
+        self._display.display(tasktime())
         self._display.display(filled("", fchar="="))
 
         timestamp(self)

--- a/plugins/callback/profile_tasks.py
+++ b/plugins/callback/profile_tasks.py
@@ -193,7 +193,10 @@ class CallbackModule(CallbackBase):
         self._display_tasktime()
 
     def playbook_on_stats(self, stats):
-        self._display_tasktime()
+        # Align summary report header with other callback plugin summary
+        self._display.banner("TASKS RECAP")
+
+        self._display.display(tasktime())
         self._display.display(filled("", fchar="="))
 
         timestamp(self)

--- a/plugins/callback/timer.py
+++ b/plugins/callback/timer.py
@@ -46,4 +46,6 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_stats(self, stats):
         end_time = datetime.utcnow()
         runtime = end_time - self.start_time
-        self._display.display("Playbook run took %s days, %s hours, %s minutes, %s seconds" % (self.days_hours_minutes_seconds(runtime)))
+        # Align summary report header with other callback plugin summary
+        self._display.banner("PLAYBOOK RECAP")
+        self._display.display("Playbook run took %s days, %s hours, %s minutes, %s seconds\n\r" % (self.days_hours_minutes_seconds(runtime)))


### PR DESCRIPTION
##### SUMMARY
All three callback plugins (timer, roles, tasks) do not produce headers in the output that align with how we do "PLAY RECAP *********" that is generated by the "default" output callback. So these changes are provided to align the callback plugins and have a clean output that is much more readable.

Note, the asterisks are generated just as how they are for "PLAY RECAP", where it extends to the end of the terminal window.

I am considering this as a "bug" in that the output was never aligned, instead of a feature since this does not provide any new feature per-se. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.posix.timer
ansible.posix.profile_tasks
ansible.posix.profile_roles

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

The new output is shown below. You can see the headers are now all the same and broken down by PLAY, ROLE, TASKS, and PLAYBOOK RECAP.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
PLAY RECAP ***************************************************************************************************************************************************************************************
localhost                  : ok=14   changed=2    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   


ROLE RECAP ***************************************************************************************************************************************************************************************
awx.awx.subscriptions --------------------------------------------------- 4.81s
users ------------------------------------------------------------------- 2.89s
labels ------------------------------------------------------------------ 2.86s
settings ---------------------------------------------------------------- 2.46s
credential_types -------------------------------------------------------- 2.27s
organizations ----------------------------------------------------------- 2.21s
teams ------------------------------------------------------------------- 2.21s
awx.awx.license --------------------------------------------------------- 1.49s
dispatch ---------------------------------------------------------------- 0.58s
credentials ------------------------------------------------------------- 0.03s
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
total ------------------------------------------------------------------ 21.80s

TASKS RECAP **************************************************************************************************************************************************************************************
Get subscriptions with a filter ----------------------------------------------------------------------------------------------------------------------------------------------------------- 4.81s
redhat_cop.controller_configuration.users : Configure Users | Wait for finish the Users creation ------------------------------------------------------------------------------------------ 1.93s
redhat_cop.controller_configuration.labels : Configure Labels | Wait for finish the Label creation ---------------------------------------------------------------------------------------- 1.91s
redhat_cop.controller_configuration.settings : Configure Settings | Wait for finish the Settings creation --------------------------------------------------------------------------------- 1.75s
redhat_cop.controller_configuration.teams : Configure Teams | Wait for finish the Teams creation ------------------------------------------------------------------------------------------ 1.63s
redhat_cop.controller_configuration.organizations : Configure Controller Organizations | Wait for finish the organization creation -------------------------------------------------------- 1.62s
Attach to a pool -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 1.49s
redhat_cop.controller_configuration.credential_types : Add Credential Types --------------------------------------------------------------------------------------------------------------- 1.32s
redhat_cop.controller_configuration.users : Add controller user --------------------------------------------------------------------------------------------------------------------------- 0.96s
redhat_cop.controller_configuration.labels : Add a label to Controller -------------------------------------------------------------------------------------------------------------------- 0.95s
redhat_cop.controller_configuration.credential_types : Configure Controller Credential Types | Wait for finish the credential types creation ---------------------------------------------- 0.94s
redhat_cop.controller_configuration.settings : Update Ansible Controller Settings from dictionary or list of dictionaries ----------------------------------------------------------------- 0.70s
redhat_cop.controller_configuration.organizations : Add organizations --------------------------------------------------------------------------------------------------------------------- 0.59s
redhat_cop.controller_configuration.teams : Create Ansible Controller Team ---------------------------------------------------------------------------------------------------------------- 0.58s
Run redhat_cop.controller_configuration.{{ __role.role }} role ---------------------------------------------------------------------------------------------------------------------------- 0.58s
redhat_cop.controller_configuration.credentials : Add Credentials ------------------------------------------------------------------------------------------------------------------------- 0.03s

PLAYBOOK RECAP ***********************************************************************************************************************************************************************************
Playbook run took 0 days, 0 hours, 0 minutes, 21 seconds

```

Current output (how it is today) for comparison:
```
PLAY RECAP ***************************************************************************************************************************************************************************************
localhost                  : ok=14   changed=2    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   

Playbook run took 0 days, 0 hours, 0 minutes, 23 seconds
Tuesday 20 September 2022  15:00:49 -0700 (0:00:00.038)       0:00:23.039 ***** 
=============================================================================== 
Get subscriptions with a filter ----------------------------------------------------------------------------------------------------------------------------------------------------------- 5.49s
redhat_cop.controller_configuration.labels : Configure Labels | Wait for finish the Label creation ---------------------------------------------------------------------------------------- 1.98s
redhat_cop.controller_configuration.users : Configure Users | Wait for finish the Users creation ------------------------------------------------------------------------------------------ 1.92s
redhat_cop.controller_configuration.organizations : Configure Controller Organizations | Wait for finish the organization creation -------------------------------------------------------- 1.84s
redhat_cop.controller_configuration.settings : Configure Settings | Wait for finish the Settings creation --------------------------------------------------------------------------------- 1.78s
redhat_cop.controller_configuration.teams : Configure Teams | Wait for finish the Teams creation ------------------------------------------------------------------------------------------ 1.61s
Attach to a pool -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 1.53s
redhat_cop.controller_configuration.credential_types : Add Credential Types --------------------------------------------------------------------------------------------------------------- 1.35s
redhat_cop.controller_configuration.users : Add controller user --------------------------------------------------------------------------------------------------------------------------- 0.95s
redhat_cop.controller_configuration.labels : Add a label to Controller -------------------------------------------------------------------------------------------------------------------- 0.95s
redhat_cop.controller_configuration.credential_types : Configure Controller Credential Types | Wait for finish the credential types creation ---------------------------------------------- 0.94s
redhat_cop.controller_configuration.settings : Update Ansible Controller Settings from dictionary or list of dictionaries ----------------------------------------------------------------- 0.73s
Run redhat_cop.controller_configuration.{{ __role.role }} role ---------------------------------------------------------------------------------------------------------------------------- 0.63s
redhat_cop.controller_configuration.organizations : Add organizations --------------------------------------------------------------------------------------------------------------------- 0.61s
redhat_cop.controller_configuration.teams : Create Ansible Controller Team ---------------------------------------------------------------------------------------------------------------- 0.60s
redhat_cop.controller_configuration.credentials : Add Credentials ------------------------------------------------------------------------------------------------------------------------- 0.04s
Tuesday 20 September 2022  15:00:49 -0700 (0:00:00.043)       0:00:23.041 ***** 
=============================================================================== 
awx.awx.subscriptions --------------------------------------------------- 5.49s
labels ------------------------------------------------------------------ 2.93s
users ------------------------------------------------------------------- 2.88s
settings ---------------------------------------------------------------- 2.51s
organizations ----------------------------------------------------------- 2.45s
credential_types -------------------------------------------------------- 2.29s
teams ------------------------------------------------------------------- 2.21s
awx.awx.license --------------------------------------------------------- 1.53s
dispatch ---------------------------------------------------------------- 0.63s
credentials ------------------------------------------------------------- 0.04s
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
total ------------------------------------------------------------------ 22.95s
```