### PR TITLE
Updat ZoneTransaction to support operations when firewalld is offline

### DIFF
--- a/changelogs/fragments/399_firewalld_create_remove_zone_when_offline.yml
+++ b/changelogs/fragments/399_firewalld_create_remove_zone_when_offline.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Fixed a bug where firewalld module fails to create/remove zones when the daemon is stopped

--- a/tests/integration/targets/firewalld/tasks/run_all_tests.yml
+++ b/tests/integration/targets/firewalld/tasks/run_all_tests.yml
@@ -16,6 +16,9 @@
 # firewalld source operation test cases
 - include_tasks: source_test_cases.yml
 
+# firewalld zone operation test cases
+- include_tasks: zone_test_cases.yml
+
 # firewalld zone target operation test cases
 - include_tasks: zone_target_test_cases.yml
 

--- a/tests/integration/targets/firewalld/tasks/zone_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/zone_test_cases.yml
@@ -1,0 +1,47 @@
+- name: firewalld create zone custom
+  firewalld:
+    zone: custom
+    permanent: True
+    state: present
+  register: result
+
+- name: assert firewalld custom zone created worked
+  assert:
+    that:
+    - result is changed
+
+- name: firewalld create zone custom rerun (verify not changed)
+  firewalld:
+    zone: custom
+    permanent: True
+    state: present
+  register: result
+
+- name: assert firewalld custom zone created worked (verify not changed)
+  assert:
+    that:
+    - result is not changed
+
+- name: firewalld remove zone custom
+  firewalld:
+    zone: custom
+    permanent: True
+    state: absent
+  register: result
+
+- name: assert firewalld custom zone removed worked
+  assert:
+    that:
+    - result is changed
+
+- name: firewalld remove custom zone rerun (verify not changed)
+  firewalld:
+    zone: custom
+    permanent: True
+    state: absent
+  register: result
+
+- name: assert firewalld custom zone removed worked (verify not changed)
+  assert:
+    that:
+    - result is not changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #398 by checking the flag self.fw_offline and calling the offline specific APIs when the flag is true.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ansible.posix.firewalld

##### ADDITIONAL INFORMATION
When attempting to add or remove zones, the ansible.posix.firewalld module would always call APIs as if it was online.

Specifically, the ZoneTransaction class assumed that self.fw  was a [FirewallClient](https://github.com/firewalld/firewalld/blob/e1407b44abc1618165accca2744226e3f0f74627/src/firewall/client.py#L2835), but when the daemon is offline, it is instead either a [Firewall](https://github.com/firewalld/firewalld/blob/e1407b44abc1618165accca2744226e3f0f74627/src/firewall/core/fw.py#L70) or [Firewall_test](https://github.com/firewalld/firewalld/blob/44200d0f508a990c5dfff9f480a6206ec507e229/src/firewall/core/fw_test.py#L55) based on the version of firewalld installed.

See #398  for additional background.

<!--- Paste verbatim command output below, e.g. before and after your change -->
###### Sample task
```yaml
- name: 'Zone example - Create new zone'
  ansible.posix.firewalld:
    zone: "example"
    state: "present"
    permanent: Yes
```

###### Before
```
The full traceback is:
  File "/tmp/ansible_ansible.posix.firewalld_payload_04lptorx/ansible_ansible.posix.firewalld_payload.zip/ansible_collections/ansible/posix/plugins/module_utils/firewalld.py", line 111, in action_handler
    return action_func(*action_func_args)
  File "/tmp/ansible_ansible.posix.firewalld_payload_04lptorx/ansible_ansible.posix.firewalld_payload.zip/ansible_collections/ansible/posix/plugins/modules/firewalld.py", line 678, in get_enabled_permanent
fatal: [boot]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "icmp_block": null,
            "icmp_block_inversion": null,
            "immediate": false,
            "interface": null,
            "masquerade": null,
            "offline": null,
            "permanent": true,
            "port": null,
            "port_forward": null,
            "rich_rule": null,
            "service": null,
            "source": null,
            "state": "present",
            "target": null,
            "timeout": 0,
            "zone": "example"
        }
    },
    "msg": "ERROR: Exception caught: 'FirewallConfig' object is not callable"
}
```

###### After
```paste below
changed: [boot] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "icmp_block": null,
            "icmp_block_inversion": null,
            "immediate": false,
            "interface": null,
            "masquerade": null,
            "offline": null,
            "permanent": true,
            "port": null,
            "port_forward": null,
            "rich_rule": null,
            "service": null,
            "source": null,
            "state": "present",
            "target": null,
            "timeout": 0,
            "zone": "example"
        }
    },
    "msg": "Permanent operation, Added zone example, Changed zone example to present, (offline operation: only on-disk configs were altered)"
```