### PR TITLE
Fix boolean values in docs

### DIFF
--- a/changelogs/fragments/400-fix-boolean-values-in-docs.yml
+++ b/changelogs/fragments/400-fix-boolean-values-in-docs.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Change boolean values in documentation to ``true/false`` (https://github.com/ansible-collections/ansible.posix/pull/400).

--- a/plugins/modules/acl.py
+++ b/plugins/modules/acl.py
@@ -20,7 +20,7 @@ options:
     description:
     - The full path of the file or object.
     type: path
-    required: yes
+    required: true
     aliases: [ name ]
   state:
     description:
@@ -33,13 +33,13 @@ options:
     description:
     - Whether to follow symlinks on the path if a symlink is encountered.
     type: bool
-    default: yes
+    default: true
   default:
     description:
-    - If the target is a directory, setting this to C(yes) will make it the default ACL for entities created inside the directory.
-    - Setting C(default) to C(yes) causes an error if the path is a file.
+    - If the target is a directory, setting this to C(true) will make it the default ACL for entities created inside the directory.
+    - Setting C(default) to C(true) causes an error if the path is a file.
     type: bool
-    default: no
+    default: false
   entity:
     description:
     - The actual user or group that the ACL applies to when matching entity types user or group are selected.
@@ -69,13 +69,13 @@ options:
     - Incompatible with C(state=query).
     - Alias C(recurse) added in version 1.3.0.
     type: bool
-    default: no
+    default: false
     aliases: [ recurse ]
   use_nfsv4_acls:
     description:
     - Use NFSv4 ACLs instead of POSIX ACLs.
     type: bool
-    default: no
+    default: false
   recalculate_mask:
     description:
     - Select if and when to recalculate the effective right masks of the files.
@@ -115,7 +115,7 @@ EXAMPLES = r'''
     entity: joe
     etype: user
     permissions: rw
-    default: yes
+    default: true
     state: present
 
 - name: Same as previous but using entry shorthand

--- a/plugins/modules/at.py
+++ b/plugins/modules/at.py
@@ -44,7 +44,7 @@ options:
     description:
      - If a matching job is present a new job will not be added.
     type: bool
-    default: no
+    default: false
 requirements:
  - at
 author:
@@ -68,7 +68,7 @@ EXAMPLES = r'''
     command: ls -d / >/dev/null
     count: 20
     units: minutes
-    unique: yes
+    unique: true
 '''
 
 import os

--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -34,13 +34,13 @@ options:
   manage_dir:
     description:
       - Whether this module should manage the directory of the authorized key file.
-      - If set to C(yes), the module will create the directory, as well as set the owner and permissions
+      - If set to C(true), the module will create the directory, as well as set the owner and permissions
         of an existing directory.
-      - Be sure to set C(manage_dir=no) if you are using an alternate directory for authorized_keys,
+      - Be sure to set C(manage_dir=false) if you are using an alternate directory for authorized_keys,
         as set with C(path), since you could lock yourself out of SSH access.
       - See the example below.
     type: bool
-    default: yes
+    default: true
   state:
     description:
       - Whether the given key (with the given key_options) should or should not be in the file.
@@ -58,15 +58,15 @@ options:
       - This option is not loop aware, so if you use C(with_) , it will be exclusive per iteration of the loop.
       - If you want multiple keys in the file you need to pass them all to C(key) in a single batch as mentioned above.
     type: bool
-    default: no
+    default: false
   validate_certs:
     description:
       - This only applies if using a https url as the source of the keys.
-      - If set to C(no), the SSL certificates will not be validated.
-      - This should only set to C(no) used on personally controlled sites using self-signed certificates as it avoids verifying the source site.
-      - Prior to 2.1 the code worked as if this was set to C(yes).
+      - If set to C(false), the SSL certificates will not be validated.
+      - This should only set to C(false) used on personally controlled sites using self-signed certificates as it avoids verifying the source site.
+      - Prior to 2.1 the code worked as if this was set to C(true).
     type: bool
-    default: yes
+    default: true
   comment:
     description:
       - Change the comment on the public key.
@@ -77,7 +77,7 @@ options:
     description:
       - Follow path symlink instead of replacing it.
     type: bool
-    default: no
+    default: false
 author: Ansible Core Team
 '''
 
@@ -106,7 +106,7 @@ EXAMPLES = r'''
     state: present
     key: "{{ lookup('file', '/home/charlie/.ssh/id_rsa.pub') }}"
     path: /etc/ssh/authorized_keys/charlie
-    manage_dir: False
+    manage_dir: false
 
 - name: Set up multiple authorized keys
   ansible.posix.authorized_key:
@@ -129,14 +129,14 @@ EXAMPLES = r'''
     user: charlie
     state: present
     key: https://github.com/user.keys
-    validate_certs: False
+    validate_certs: false
 
 - name: Set authorized key, removing all the authorized keys already set
   ansible.posix.authorized_key:
     user: root
     key: "{{ lookup('file', 'public_keys/doe-jane') }}"
     state: present
-    exclusive: True
+    exclusive: true
 
 - name: Set authorized key for user ubuntu copying it from current user
   ansible.posix.authorized_key:
@@ -150,7 +150,7 @@ exclusive:
   description: If the key has been forced to be exclusive or not.
   returned: success
   type: bool
-  sample: False
+  sample: false
 key:
   description: The key that the module was running against.
   returned: success
@@ -170,7 +170,7 @@ manage_dir:
   description: Whether this module managed the directory of the authorized key file.
   returned: success
   type: bool
-  sample: True
+  sample: true
 path:
   description: Alternate path to the authorized_keys file
   returned: success
@@ -192,7 +192,7 @@ user:
   type: str
   sample: user
 validate_certs:
-  description: This only applies if using a https url as the source of the keys. If set to C(no), the SSL certificates will not be validated.
+  description: This only applies if using a https url as the source of the keys. If set to C(false), the SSL certificates will not be validated.
   returned: success
   type: bool
   sample: true

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -82,13 +82,13 @@ options:
     description:
       - Should this configuration be in the running firewalld configuration or persist across reboots.
       - As of Ansible 2.3, permanent operations can operate on firewalld configs when it is not running (requires firewalld >= 0.3.9).
-      - Note that if this is C(no), immediate is assumed C(yes).
+      - Note that if this is C(false), immediate is assumed C(true).
     type: bool
   immediate:
     description:
       - Should this configuration be applied immediately, if set as permanent.
     type: bool
-    default: no
+    default: false
   state:
     description:
       - Enable or disable a setting.
@@ -141,29 +141,29 @@ EXAMPLES = r'''
 - name: permit traffic in default zone for https service
   ansible.posix.firewalld:
     service: https
-    permanent: yes
+    permanent: true
     state: enabled
 
 - name: do not permit traffic in default zone on port 8081/tcp
   ansible.posix.firewalld:
     port: 8081/tcp
-    permanent: yes
+    permanent: true
     state: disabled
 
 - ansible.posix.firewalld:
     port: 161-162/udp
-    permanent: yes
+    permanent: true
     state: enabled
 
 - ansible.posix.firewalld:
     zone: dmz
     service: http
-    permanent: yes
+    permanent: true
     state: enabled
 
 - ansible.posix.firewalld:
     rich_rule: rule service name="ftp" audit limit value="1/m" accept
-    permanent: yes
+    permanent: true
     state: enabled
 
 - ansible.posix.firewalld:
@@ -174,44 +174,44 @@ EXAMPLES = r'''
 - ansible.posix.firewalld:
     zone: trusted
     interface: eth2
-    permanent: yes
+    permanent: true
     state: enabled
 
 - ansible.posix.firewalld:
-    masquerade: yes
+    masquerade: true
     state: enabled
-    permanent: yes
+    permanent: true
     zone: dmz
 
 - ansible.posix.firewalld:
     zone: custom
     state: present
-    permanent: yes
+    permanent: true
 
 - ansible.posix.firewalld:
     zone: drop
     state: enabled
-    permanent: yes
-    icmp_block_inversion: yes
+    permanent: true
+    icmp_block_inversion: true
 
 - ansible.posix.firewalld:
     zone: drop
     state: enabled
-    permanent: yes
+    permanent: true
     icmp_block: echo-request
 
 - ansible.posix.firewalld:
     zone: internal
     state: present
-    permanent: yes
+    permanent: true
     target: ACCEPT
 
 - name: Redirect port 443 to 8443 with Rich Rule
   ansible.posix.firewalld:
     rich_rule: rule family=ipv4 forward-port port=443 protocol=tcp to-port=8443
     zone: public
-    permanent: yes
-    immediate: yes
+    permanent: true
+    immediate: true
     state: enabled
 '''
 

--- a/plugins/modules/firewalld_info.py
+++ b/plugins/modules/firewalld_info.py
@@ -17,7 +17,7 @@ options:
     active_zones:
         description: Gather information about active zones.
         type: bool
-        default: no
+        default: false
     zones:
         description:
             - Gather information about specific zones.
@@ -36,7 +36,7 @@ author:
 EXAMPLES = r'''
 - name: Gather information about active zones
   ansible.posix.firewalld_info:
-    active_zones: yes
+    active_zones: true
 
 - name: Gather information about specific zones
   ansible.posix.firewalld_info:

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -101,13 +101,13 @@ options:
       - To avoid mount option conflicts, if C(noauto) specified in C(opts),
         mount module will ignore C(boot).
     type: bool
-    default: yes
+    default: true
   backup:
     description:
       - Create a backup file including the timestamp information so you can get
         the original file back if you somehow clobbered it incorrectly.
     type: bool
-    default: no
+    default: false
 notes:
   - As of Ansible 2.3, the I(name) option has been changed to I(path) as
     default, but I(name) still works as well.
@@ -181,7 +181,7 @@ EXAMPLES = r'''
     src: 192.168.1.100:/nfs/ssd/shared_data
     path: /mnt/shared_data
     opts: rw,sync,hard
-    boot: no
+    boot: false
     state: mounted
     fstype: nfs
 '''

--- a/plugins/modules/patch.py
+++ b/plugins/modules/patch.py
@@ -50,10 +50,10 @@ options:
     default: present
   remote_src:
     description:
-      - If C(no), it will search for src at originating/controller machine, if C(yes) it will
+      - If C(false), it will search for src at originating/controller machine, if C(true) it will
         go to the remote/target machine for the C(src).
     type: bool
-    default: no
+    default: false
   strip:
     description:
       - Number that indicates the smallest prefix containing leading slashes
@@ -65,20 +65,20 @@ options:
     description:
       - Passes C(--backup --version-control=numbered) to patch, producing numbered backup copies.
     type: bool
-    default: no
+    default: false
   binary:
     description:
-      - Setting to C(yes) will disable patch's heuristic for transforming CRLF
+      - Setting to C(true) will disable patch's heuristic for transforming CRLF
         line endings into LF.
       - Line endings of src and dest must match.
-      - If set to C(no), C(patch) will replace CRLF in C(src) files on POSIX.
+      - If set to C(false), C(patch) will replace CRLF in C(src) files on POSIX.
     type: bool
-    default: no
+    default: false
   ignore_whitespace:
     description:
-      - Setting to C(yes) will ignore white space changes between patch and input..
+      - Setting to C(true) will ignore white space changes between patch and input.
     type: bool
-    default: no
+    default: false
 notes:
   - This module requires GNU I(patch) utility to be installed on the remote host.
 '''

--- a/plugins/modules/seboolean.py
+++ b/plugins/modules/seboolean.py
@@ -22,9 +22,9 @@ options:
     type: str
   persistent:
     description:
-      - Set to C(yes) if the boolean setting should survive a reboot.
+      - Set to C(true) if the boolean setting should survive a reboot.
     type: bool
-    default: 'no'
+    default: false
   state:
     description:
       - Desired boolean value
@@ -49,8 +49,8 @@ EXAMPLES = r'''
 - name: Set httpd_can_network_connect flag on and keep it persistent across reboots
   ansible.posix.seboolean:
     name: httpd_can_network_connect
-    state: yes
-    persistent: yes
+    state: true
+    persistent: true
 '''
 
 import os

--- a/plugins/modules/selinux.py
+++ b/plugins/modules/selinux.py
@@ -32,7 +32,7 @@ options:
     description:
       - If set to I(true), will update also the kernel boot parameters when disabling/enabling SELinux.
       - The C(grubby) tool must be present on the target system for this to work.
-    default: no
+    default: false
     type: bool
     version_added: '1.4.0'
   configfile:

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -53,36 +53,36 @@ options:
     description:
       - Mirrors the rsync archive flag, enables recursive, links, perms, times, owner, group flags and -D.
     type: bool
-    default: yes
+    default: true
   checksum:
     description:
       - Skip based on checksum, rather than mod-time & size; Note that that "archive" option is still enabled by default - the "checksum" option will
         not disable it.
     type: bool
-    default: no
+    default: false
   compress:
     description:
       - Compress file data during the transfer.
       - In most cases, leave this enabled unless it causes problems.
     type: bool
-    default: yes
+    default: true
   existing_only:
     description:
       - Skip creating new files on receiver.
     type: bool
-    default: no
+    default: false
   delete:
     description:
       - Delete files in I(dest) that do not exist (after transfer, not before) in the I(src) path.
-      - This option requires I(recursive=yes).
+      - This option requires I(recursive=true).
       - This option ignores excluded files and behaves like the rsync opt C(--delete-after).
     type: bool
-    default: no
+    default: false
   dirs:
     description:
       - Transfer directories without recursing.
     type: bool
-    default: no
+    default: false
   recursive:
     description:
       - Recurse into directories.
@@ -97,7 +97,7 @@ options:
     description:
       - Copy symlinks as the item that they point to (the referent) is copied, rather than the symlink.
     type: bool
-    default: no
+    default: false
   perms:
     description:
       - Preserve permissions.
@@ -132,26 +132,26 @@ options:
     description:
       - Put user@ for the remote paths.
       - If you have a custom ssh config to define the remote user for a host
-        that does not match the inventory user, you should set this parameter to C(no).
+        that does not match the inventory user, you should set this parameter to C(false).
     type: bool
-    default: yes
+    default: true
   use_ssh_args:
     description:
       - In Ansible 2.10 and lower, it uses the ssh_args specified in C(ansible.cfg).
       - In Ansible 2.11 and onwards, when set to C(true), it uses all SSH connection configurations like
         C(ansible_ssh_args), C(ansible_ssh_common_args), and C(ansible_ssh_extra_args).
     type: bool
-    default: no
+    default: false
   ssh_connection_multiplexing:
     description:
       - SSH connection multiplexing for rsync is disabled by default to prevent misconfigured ControlSockets from resulting in failed SSH connections.
         This is accomplished by setting the SSH C(ControlSocket) to C(none).
-      - Set this option to C(yes) to allow multiplexing and reduce SSH connection overhead.
-      - Note that simply setting this option to C(yes) is not enough;
+      - Set this option to C(true) to allow multiplexing and reduce SSH connection overhead.
+      - Note that simply setting this option to C(true) is not enough;
         You must also configure SSH connection multiplexing in your SSH client config by setting values for
         C(ControlMaster), C(ControlPersist) and C(ControlPath).
     type: bool
-    default: no
+    default: false
   rsync_opts:
     description:
       - Specify additional rsync options by passing in an array.
@@ -163,12 +163,12 @@ options:
     description:
       - Tells rsync to keep the partial file which should make a subsequent transfer of the rest of the file much faster.
     type: bool
-    default: no
+    default: false
   verify_host:
     description:
       - Verify destination host key.
     type: bool
-    default: no
+    default: false
   private_key:
     description:
       - Specify the private key to use for SSH-based rsync connections (e.g. C(~/.ssh/id_rsa)).
@@ -184,7 +184,7 @@ options:
       - This option puts the temporary file from each updated file into a holding directory until the end of the transfer,
         at which time all the files are renamed into place in rapid succession.
     type: bool
-    default: yes
+    default: true
     version_added: '1.3.0'
 
 notes:
@@ -252,27 +252,27 @@ EXAMPLES = r'''
   ansible.posix.synchronize:
     src: some/relative/path
     dest: /some/absolute/path
-    archive: no
+    archive: false
 
 - name: Synchronization with --archive options enabled except for --recursive
   ansible.posix.synchronize:
     src: some/relative/path
     dest: /some/absolute/path
-    recursive: no
+    recursive: false
 
 - name: Synchronization with --archive options enabled except for --times, with --checksum option enabled
   ansible.posix.synchronize:
     src: some/relative/path
     dest: /some/absolute/path
-    checksum: yes
-    times: no
+    checksum: true
+    times: false
 
 - name: Synchronization without --archive options enabled except use --links
   ansible.posix.synchronize:
     src: some/relative/path
     dest: /some/absolute/path
-    archive: no
-    links: yes
+    archive: false
+    links: true
 
 - name: Synchronization of two paths both on the control machine
   ansible.posix.synchronize:
@@ -302,8 +302,8 @@ EXAMPLES = r'''
   ansible.posix.synchronize:
     src: some/relative/path
     dest: /some/absolute/path
-    delete: yes
-    recursive: yes
+    delete: true
+    recursive: true
 
 # This specific command is granted su privileges on the destination
 - name: Synchronize using an alternate rsync command

--- a/plugins/modules/sysctl.py
+++ b/plugins/modules/sysctl.py
@@ -38,14 +38,14 @@ options:
         description:
             - Use this option to ignore errors about unknown keys.
         type: bool
-        default: 'no'
+        default: false
     reload:
         description:
-            - If C(yes), performs a I(/sbin/sysctl -p) if the C(sysctl_file) is
-              updated. If C(no), does not reload I(sysctl) even if the
+            - If C(true), performs a I(/sbin/sysctl -p) if the C(sysctl_file) is
+              updated. If C(false), does not reload I(sysctl) even if the
               C(sysctl_file) is updated.
         type: bool
-        default: 'yes'
+        default: true
     sysctl_file:
         description:
             - Specifies the absolute path to C(sysctl.conf), if not C(/etc/sysctl.conf).
@@ -53,9 +53,9 @@ options:
         type: path
     sysctl_set:
         description:
-            - Verify token value with the sysctl command and set with -w if necessary
+            - Verify token value with the sysctl command and set with -w if necessary.
         type: bool
-        default: 'no'
+        default: false
 author:
 - David CHANIAL (@davixx)
 '''
@@ -78,21 +78,21 @@ EXAMPLES = r'''
     name: kernel.panic
     value: '3'
     sysctl_file: /tmp/test_sysctl.conf
-    reload: no
+    reload: false
 
 # Set ip forwarding on in /proc and verify token value with the sysctl command
 - ansible.posix.sysctl:
     name: net.ipv4.ip_forward
     value: '1'
-    sysctl_set: yes
+    sysctl_set: true
 
 # Set ip forwarding on in /proc and in the sysctl file and reload if necessary
 - ansible.posix.sysctl:
     name: net.ipv4.ip_forward
     value: '1'
-    sysctl_set: yes
+    sysctl_set: true
     state: present
-    reload: yes
+    reload: true
 '''
 
 # ==============================================================


### PR DESCRIPTION
##### SUMMARY
Fixes #397

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
Docs of several modules

##### ADDITIONAL INFORMATION
Notes about testing. I'm not sure how to test collections properly. I have ran `ansible-test sanity --python 3.10` and `ansible-test units --python 3.10` in venv with `ansible-core 2.14` (with 0 return code in both cases). To run units test successfully I had to install `pytest-forked` pip package in addition to this one `pytest-xdist` from [test-requirements.txt](https://github.com/ansible-collections/ansible.posix/blob/main/test-requirements.txt#L2).

Note about issue #397. I haven't changed `yes` [here](https://github.com/ansible-collections/ansible.posix/blob/main/plugins/modules/mount.py#L97) because in this case it is value from `/etc/vfstab`. Also I've changed `yes` for parameters `masquerade` and `icmp_block_inversion` because they both are converted to bool by `boolean` function and will be changed to boolean in a future release ([1](https://github.com/ansible-collections/ansible.posix/blob/main/plugins/modules/firewalld.py#L864), [2](https://github.com/ansible-collections/ansible.posix/blob/main/plugins/modules/firewalld.py#L989)), for `required` too.