### PR TITLE
Update documented default parameters to match implementation

### DIFF
--- a/changelogs/fragments/401_document_module_default_values.yml
+++ b/changelogs/fragments/401_document_module_default_values.yml
@@ -1,0 +1,4 @@
+---
+trivial:
+- acl - document default value for the ``entry`` parameter
+- rhel_rpm_ostree - document default value for the ``name`` parameter

--- a/plugins/modules/acl.py
+++ b/plugins/modules/acl.py
@@ -44,6 +44,7 @@ options:
     description:
     - The actual user or group that the ACL applies to when matching entity types user or group are selected.
     type: str
+    default: ""
   etype:
     description:
     - The entity type of the ACL to apply, see C(setfacl) documentation for more info.

--- a/plugins/modules/rhel_rpm_ostree.py
+++ b/plugins/modules/rhel_rpm_ostree.py
@@ -35,6 +35,7 @@ options:
     aliases: [ pkg ]
     type: list
     elements: str
+    default: []
   state:
     description:
       - Whether to install (C(present) or C(installed), C(latest)), or remove (C(absent) or C(removed)) a package.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Updates documented default value for the acl module's entity parameter to an empty string and rhel_rpm_ostree's name parameter to an empty array correctly matching the actual implementation in both cases. This should fix currently failing test cases in the devel and milestone branches of CI/CD.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.posix.acl
ansible.posix.rhel_rpm_ostree

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Display the current documentation for the acl module using `ansible-doc ansible.posix.acl` or rhel_rpm_ostree module using `ansible-doc ansible.posix.rhel_rpm_ostree`

Alternatively using ansible-test on devel/milestone branches of ansible, execute:
`ansible-test sanity --test validate-modules plugins/modules/`

```
Running sanity test "validate-modules"
ERROR: Found 2 validate-modules issue(s) which need to be resolved:
ERROR: plugins/modules/acl.py:0:0: doc-default-does-not-match-spec: Argument 'entity' in argument_spec defines default as ('') but documentation defines default as (None)
ERROR: plugins/modules/rhel_rpm_ostree.py:0:0: doc-default-does-not-match-spec: Argument 'name' in argument_spec defines default as ([]) but documentation defines default as (None)
```

<!--- Paste verbatim command output below, e.g. before and after your change -->
###### Before (ansible.posix.acl)
```
- entity
        The actual user or group that the ACL applies to when matching
        entity types user or group are selected.
        [Default: (null)]
        type: str
```

###### After (ansible.posix.acl)
```
- entity
        The actual user or group that the ACL applies to when matching
        entity types user or group are selected.
        [Default: ]
        type: str
```

###### Before (ansible.posix.rhel_rpm_ostree)
```
- name
        A package name or package specifier with version, like
        `name-1.0'.
        Comparison operators for package version are valid here `>',
        `<', `>=', `<='. Example - `name>=1.0'
        If a previous version is specified, the task also needs to
        turn `allow_downgrade' on. See the `allow_downgrade'
        documentation for caveats with downgrading packages.
        When using state=latest, this can be `'*'' which means run
        `yum -y update'.
        You can also pass a url or a local path to a rpm file (using
        state=present). To operate on several packages this can accept
        a comma separated string of packages or (as of 2.0) a list of
        packages.
        aliases: [pkg]
        default: null
        elements: str
        type: list
```

###### After (ansible.posix.rhel_rpm_ostree)
```
- name
        A package name or package specifier with version, like
        `name-1.0'.
        Comparison operators for package version are valid here `>',
        `<', `>=', `<='. Example - `name>=1.0'
        If a previous version is specified, the task also needs to
        turn `allow_downgrade' on. See the `allow_downgrade'
        documentation for caveats with downgrading packages.
        When using state=latest, this can be `'*'' which means run
        `yum -y update'.
        You can also pass a url or a local path to a rpm file (using
        state=present). To operate on several packages this can accept
        a comma separated string of packages or (as of 2.0) a list of
        packages.
        aliases: [pkg]
        default: []
        elements: str
        type: list
```

