### PR TITLE
Bugfix masquerade icmp block inversion

### DIFF
--- a/changelogs/fragments/404_firewalld_masquerade_icmp_block_inversion_bugfixes.yml
+++ b/changelogs/fragments/404_firewalld_masquerade_icmp_block_inversion_bugfixes.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - firewalld - Consider value of masquerade and icmp_block_inversion parameters when a boolean like value is passed

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -846,12 +846,21 @@ def main():
             msgs.append("Changed icmp-block %s to %s" % (icmp_block, desired_state))
 
     if icmp_block_inversion is not None:
+        # Type of icmp_block_inversion will be changed to boolean in a future release.
+        icmp_block_inversion_status = True
+        try:
+            icmp_block_inversion_status = boolean(icmp_block_inversion, True)
+        except TypeError:
+            module.warn('The value of the icmp_block_inversion option is "%s". '
+                        'The type of the option will be changed from string to boolean in a future release. '
+                        'To avoid unexpected behavior, please change the value to boolean.' % icmp_block_inversion)
+        expected_state = 'enabled' if (desired_state == 'enabled') == icmp_block_inversion_status else 'disabled'
 
         transaction = IcmpBlockInversionTransaction(
             module,
             action_args=(),
             zone=zone,
-            desired_state=desired_state,
+            desired_state=expected_state,
             permanent=permanent,
             immediate=immediate,
         )
@@ -860,14 +869,6 @@ def main():
         msgs = msgs + transaction_msgs
         if changed is True:
             msgs.append("Changed icmp-block-inversion %s to %s" % (icmp_block_inversion, desired_state))
-
-        # Type of icmp_block_inversion will be changed to boolean in a future release.
-        try:
-            boolean(icmp_block_inversion, True)
-        except TypeError:
-            module.warn('The value of the icmp_block_inversion option is "%s". '
-                        'The type of the option will be changed from string to boolean in a future release. '
-                        'To avoid unexpected behavior, please change the value to boolean.' % icmp_block_inversion)
 
     if service is not None:
 

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -973,26 +973,27 @@ def main():
         msgs = msgs + transaction_msgs
 
     if masquerade is not None:
+        # Type of masquerade will be changed to boolean in a future release.
+        masquerade_status = True
+        try:
+            masquerade_status = boolean(masquerade, True)
+        except TypeError:
+            module.warn('The value of the masquerade option is "%s". '
+                        'The type of the option will be changed from string to boolean in a future release. '
+                        'To avoid unexpected behavior, please change the value to boolean.' % masquerade)
 
+        expected_state = 'enabled' if (desired_state == 'enabled') == masquerade_status else 'disabled'
         transaction = MasqueradeTransaction(
             module,
             action_args=(),
             zone=zone,
-            desired_state=desired_state,
+            desired_state=expected_state,
             permanent=permanent,
             immediate=immediate,
         )
 
         changed, transaction_msgs = transaction.run()
         msgs = msgs + transaction_msgs
-
-        # Type of masquerade will be changed to boolean in a future release.
-        try:
-            boolean(masquerade, True)
-        except TypeError:
-            module.warn('The value of the masquerade option is "%s". '
-                        'The type of the option will be changed from string to boolean in a future release. '
-                        'To avoid unexpected behavior, please change the value to boolean.' % masquerade)
 
     if target is not None:
 

--- a/tests/integration/targets/firewalld/tasks/icmp_block_inversion_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/icmp_block_inversion_test_cases.yml
@@ -1,0 +1,172 @@
+# Test playbook for the firewalld module - icmp block inversion operations
+# (c) 2022, Gregory Furlong <gnfzdz@fzdz.io>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Icmp block inversion enabled when icmp block inversion is truthy and state is enabled
+  block:
+  - name: Testing enable icmp block inversion
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: yes
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert icmp block inversion is enabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing enable icmp block inversion (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: yes
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert icmp block inversion is enabled (verify not changed)
+    assert:
+      that:
+      - result is not changed
+
+- name: Icmp block inversion disabled when icmp block inversion is falsy and state is enabled
+  block:
+  - name: Testing disable icmp block inversion
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: no
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert icmp block inversion is disabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing disable icmp block inversion (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: no
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert icmp block inversion is disabled (verify not changed)
+    assert:
+      that:
+      - result is not changed
+
+- name: Icmp block inversion enabled when icmp block inversion is falsy and state is disabled
+  block:
+  - name: Testing enable icmp block inversion
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: no
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert icmp block inversion is enabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing enable icmp block inversion (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: no
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert icmp block inversion is enabled (verify not changed)
+    assert:
+      that:
+      - result is not changed
+
+- name: Icmp block inversion disabled when icmp block inversion is truthy and state is disabled
+  block:
+  - name: Testing disable icmp block inversion
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: yes
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert icmp block inversion is disabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing disable icmp block inversion (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: yes
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert icmp block inversion is disabled (verify not changed)
+    assert:
+      that:
+      - result is not changed
+
+# Validate backwards compatible behavior until icmp block inversion is switched from string to boolean type
+- name: Icmp block inversion enabled when icmp block inversion is non-boolean string and state is enabled
+  block:
+  - name: Testing enable icmp block inversion
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: 'some string'
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert icmp block inversion is enabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing enable icmp block inversion (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: 'some string'
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert icmp block inversion is enabled (verify not changed)
+    assert:
+      that:
+      - result is not changed
+
+- name: Icmp block inversion disabled when icmp block inversion is non-boolean string and state is disabled
+  block:
+  - name: Testing disable icmp block inversion
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: 'some string'
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert icmp block inversion is disabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing disable icmp block inversion (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      icmp_block_inversion: 'some string'
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert icmp block inversion is disabled (verify not changed)
+    assert:
+      that:
+      - result is not changed

--- a/tests/integration/targets/firewalld/tasks/masquerade_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/masquerade_test_cases.yml
@@ -1,0 +1,172 @@
+# Test playbook for the firewalld module
+# (c) 2022, Gregory Furlong <gnfzdz@fzdz.io>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Masquerade enabled when masquerade is truthy and state is enabled
+  block:
+  - name: Testing enable masquerade
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: yes
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert masquerade is enabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing enable masquerade (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: yes
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert masquerade is enabled (verify not changed)
+    assert:
+      that:
+      - result is not changed
+
+- name: Masquerade disabled when masquerade is falsy and state is enabled
+  block:
+  - name: Testing disable masquerade
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: no
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert masquerade is disabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing disable masquerade (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: no
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert masquerade is disabled (verify not changed)
+    assert:
+      that:
+      - result is not changed
+
+- name: Masquerade enabled when masquerade is falsy and state is disabled
+  block:
+  - name: Testing enable masquerade
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: no
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert masquerade is enabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing enable masquerade (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: no
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert masquerade is enabled (verify not changed)
+    assert:
+      that:
+      - result is not changed
+
+- name: Masquerade disabled when masquerade is truthy and state is disabled
+  block:
+  - name: Testing disable masquerade
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: yes
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert masquerade is disabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing disable masquerade (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: yes
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert masquerade is disabled (verify not changed)
+    assert:
+      that:
+      - result is not changed
+
+# Validate backwards compatible behavior until masquerade is switched from string to boolean type
+- name: Masquerade enabled when masquerade is non-boolean string and state is enabled
+  block:
+  - name: Testing enable masquerade
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: 'some string'
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert masquerade is enabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing enable masquerade (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: 'some string'
+      permanent:  yes
+      state:      enabled
+    register: result
+
+  - name: assert masquerade is enabled (verify not changed)
+    assert:
+      that:
+      - result is not changed
+
+- name: Masquerade disabled when masquerade is non-boolean string and state is disabled
+  block:
+  - name: Testing disable masquerade
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: 'some string'
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert masquerade is disabled
+    assert:
+      that:
+      - result is changed
+
+  - name: Testing disable masquerade (verify not changed)
+    ansible.posix.firewalld:
+      zone:       trusted
+      masquerade: 'some string'
+      permanent:  yes
+      state:      disabled
+    register: result
+
+  - name: assert masquerade is disabled (verify not changed)
+    assert:
+      that:
+      - result is not changed

--- a/tests/integration/targets/firewalld/tasks/masquerade_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/masquerade_test_cases.yml
@@ -1,4 +1,4 @@
-# Test playbook for the firewalld module
+# Test playbook for the firewalld module - masquerade operations
 # (c) 2022, Gregory Furlong <gnfzdz@fzdz.io>
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 

--- a/tests/integration/targets/firewalld/tasks/run_all_tests.yml
+++ b/tests/integration/targets/firewalld/tasks/run_all_tests.yml
@@ -24,3 +24,6 @@
 
 # firewalld masquerade operation test cases
 - include_tasks: masquerade_test_cases.yml
+
+# firewalld icmp block inversion operation test cases
+- include_tasks: icmp_block_inversion_test_cases.yml

--- a/tests/integration/targets/firewalld/tasks/run_all_tests.yml
+++ b/tests/integration/targets/firewalld/tasks/run_all_tests.yml
@@ -21,3 +21,6 @@
 
 # firewalld port forwarding operation test cases
 - include_tasks: port_forward_test_cases.yml
+
+# firewalld masquerade operation test cases
+- include_tasks: masquerade_test_cases.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #235
Fixes #116

The masquerade and icmp_block_inversion parameters are currently strings and the values are completely ignored by the module.  A warning was previously added that these values will be converted to a boolean in the future.

This PR updates the behavior so that when a boolean like value is provided, the value is correctly considered. If a boolean like string is **NOT** provided, the current behavior is retained and the value is treated as true.  Additionally, comprehensive tests are added for every combination of the parameters `state` _(enabled/disabled)_ and `icmp_block_inversion` / `masquerade` _(True/False/non-boolean string)_.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.posix.firewalld

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Given icmp block inversion is currently enabled

```
  - name: Testing disable icmp block inversion
    ansible.posix.firewalld:
      zone:       trusted
      icmp_block_inversion: no
      permanent:  yes
      state:      enabled
```

##### Before
```
TASK [firewalld : Testing disable icmp block inversion] ************************
task path: /root/ansible_collections/ansible/posix/tests/output/.tmp/integration/firewalld-96jns0q4-ÅÑŚÌβŁÈ/tests/integration/targets/firewalld/tasks/icmp_block_inversion_test_cases.yml:35
Using module file /root/ansible_collections/ansible/posix/plugins/modules/firewalld.py
Pipelining is enabled.
<testhost> ESTABLISH LOCAL CONNECTION FOR USER: root
<testhost> EXEC /bin/sh -c '/usr/bin/python3.10 && sleep 0'
ok: [testhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "icmp_block": null,
            "icmp_block_inversion": "False",
            "immediate": false,
            "interface": null,
            "masquerade": null,
            "offline": null,
            "permanent": true,
            "port": null,
            "port_forward": null,
            "rich_rule": null,
            "service": null,
            "source": null,
            "state": "enabled",
            "target": null,
            "timeout": 0,
            "zone": "trusted"
        }
    },
    "msg": "Permanent operation"
}
```

##### After
```
TASK [firewalld : Testing disable icmp block inversion] ************************
task path: /root/ansible_collections/ansible/posix/tests/output/.tmp/integration/firewalld-nxphh1pk-ÅÑŚÌβŁÈ/tests/integration/targets/firewalld/tasks/icmp_block_inversion_test_cases.yml:35
Using module file /root/ansible_collections/ansible/posix/plugins/modules/firewalld.py
Pipelining is enabled.
<testhost> ESTABLISH LOCAL CONNECTION FOR USER: root
<testhost> EXEC /bin/sh -c '/usr/bin/python3.10 && sleep 0'
changed: [testhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "icmp_block": null,
            "icmp_block_inversion": "False",
            "immediate": false,
            "interface": null,
            "masquerade": null,
            "offline": null,
            "permanent": true,
            "port": null,
            "port_forward": null,
            "rich_rule": null,
            "service": null,
            "source": null,
            "state": "enabled",
            "target": null,
            "timeout": 0,
            "zone": "trusted"
        }
    },
    "msg": "Permanent operation, Changed icmp-block-inversion False to enabled"
}
```