### PR TITLE
Add new feature to firewalld module allowing the default zone to be set.

### DIFF
--- a/tests/integration/targets/firewalld/tasks/main.yml
+++ b/tests/integration/targets/firewalld/tasks/main.yml
@@ -40,6 +40,8 @@
             state: stopped
 
         - import_tasks: run_all_tests.yml
+          # FIXME currently fails when the daemon is running AND executed inside a container
+        - import_tasks: zone_default_test_cases.yml
       when: check_output.rc == 0
 
   when:

--- a/tests/integration/targets/firewalld/tasks/source_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/source_test_cases.yml
@@ -82,4 +82,4 @@
   assert:
     that:
     - result is not changed
-    - "result.msg == 'parameters are mutually exclusive: icmp_block|icmp_block_inversion|service|port|port_forward|rich_rule|interface|masquerade|source|target'"
+    - "result.msg == 'parameters are mutually exclusive: icmp_block|icmp_block_inversion|service|port|port_forward|rich_rule|interface|masquerade|source|target|default'"

--- a/tests/integration/targets/firewalld/tasks/zone_default_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/zone_default_test_cases.yml
@@ -1,0 +1,115 @@
+# Test playbook for the firewalld module - zone default operations
+# (c) 2022, Gregory Furlong <gnfzdz@fzdz.io>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+- name: Set default zone to trusted (default - true / state - enabled)
+  block:
+  - name: Update default zone to trusted
+    ansible.posix.firewalld:
+      zone: trusted
+      default: True
+      permanent: True
+      state: enabled
+    register: result
+
+  - name: Default zone is trusted
+    ansible.builtin.assert:
+      that:
+        - result is changed
+
+  - name: Update default zone to trusted (verify not changed)
+    ansible.posix.firewalld:
+      zone: trusted
+      default: True
+      permanent: True
+      state: enabled
+    register: result
+
+  - name: Default zone is trusted (verify not changed)
+    ansible.builtin.assert:
+      that:
+        - result is not changed
+
+- name: Revert default zone to upstream default (default - false / state - enabled)
+  block:
+  - name: Revert default zone to upstream default
+    ansible.posix.firewalld:
+      zone: trusted
+      default: False
+      permanent: True
+      state: enabled
+    register: result
+
+  - name: Default zone is reverted
+    ansible.builtin.assert:
+      that:
+        - result is changed
+
+  - name: Revert default zone to upstream default (verify not changed)
+    ansible.posix.firewalld:
+      zone: trusted
+      default: False
+      permanent: True
+      state: enabled
+    register: result
+
+  - name: Default zone is reverted (verify not changed)
+    ansible.builtin.assert:
+      that:
+        - result is not changed
+
+- name: Set default zone to trusted (default - false / state - disabled)
+  block:
+  - name: Update default zone to trusted
+    ansible.posix.firewalld:
+      zone: trusted
+      default: False
+      permanent: True
+      state: disabled
+    register: result
+
+  - name: Default zone is trusted
+    ansible.builtin.assert:
+      that:
+        - result is changed
+
+  - name: Update default zone to trusted (verify not changed)
+    ansible.posix.firewalld:
+      zone: trusted
+      default: False
+      permanent: True
+      state: disabled
+    register: result
+
+  - name: Default zone is trusted (verify not changed)
+    ansible.builtin.assert:
+      that:
+        - result is not changed
+
+- name: Revert default zone to upstream default (default - true / state - disabled)
+  block:
+  - name: Revert default zone to upstream default
+    ansible.posix.firewalld:
+      zone: trusted
+      default: True
+      permanent: True
+      state: disabled
+    register: result
+
+  - name: Default zone is reverted
+    ansible.builtin.assert:
+      that:
+        - result is changed
+
+  - name: Revert default zone to upstream default (verify not changed)
+    ansible.posix.firewalld:
+      zone: trusted
+      default: True
+      permanent: True
+      state: disabled
+    register: result
+
+  - name: Default zone is reverted (verify not changed)
+    ansible.builtin.assert:
+      that:
+        - result is not changed


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Implements #296 adding support for setting the default zone in the firewalld module.

This pull request is meant to help visualize the changes mentioned in the linked issue and I'm more interested in feedback than actually having it merged.

Related to my concerns from comments in that issue:
1. For consistency with the rest of the module, the `state` parameter is retained although it may have unclear semantics when considering negative values.
2. When the indicated zone is currently the default AND the combination of the `state` and `default` parameters would suggest that the zone should NOT be, the module reverts the default zone back to the upstream default, public
3. As with the existing ZoneTransaction, an error is returned if the caller doesn't explicitly request for the change to be permanent (as transient changes don't appear to be supported for this setting as far as I can tell). This alone might not be sufficient as when the daemon is running, the change is always both immediate and permanent.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.posix.firewalld

##### ADDITIONAL INFORMATION

<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
  - name: Update default zone to trusted
    ansible.posix.firewalld:
      zone: trusted
      default: True
      permanent: True
      state: enabled
```

```
TASK [firewalld : Update default zone to trusted] ******************************
task path: /root/ansible_collections/ansible/posix/tests/output/.tmp/integration/firewalld-6xmdfto8-ÅÑŚÌβŁÈ/tests/integration/targets/firewalld/tasks/zone_default_test_cases.yml:7
Using module file /root/ansible_collections/ansible/posix/plugins/modules/firewalld.py
Pipelining is enabled.
<testhost> ESTABLISH LOCAL CONNECTION FOR USER: root
<testhost> EXEC /bin/sh -c '/usr/bin/python3.10 && sleep 0'
changed: [testhost] => {
    "changed": true,
    "invocation": {
        "module_args": {
            "default": true,
            "icmp_block": null,
            "icmp_block_inversion": null,
            "immediate": false,
            "interface": null,
            "masquerade": null,
            "offline": null,
            "permanent": true,
            "port": null,
            "port_forward": null,
            "rich_rule": null,
            "service": null,
            "source": null,
            "state": "enabled",
            "target": null,
            "timeout": 0,
            "zone": "trusted"
        }
    },
    "msg": "Permanent operation, Updated default zone to trusted, (offline operation: only on-disk configs were altered)"
}
```

Note: The new integration test cases currently fail for the scenario where the daemon is up AND they are run in a container (as with CI/CD). In that scenario, it correctly updates the default zone to /etc/firewalld/firewalld.conf but fails when attempting to immediately apply the change to nftables. In my tests running on bare metal and a full VM they appear to work without issue.
```
TASK [firewalld : Update default zone to trusted] ******************************
task path: /root/ansible_collections/ansible/posix/tests/output/.tmp/integration/firewalld-8puctpub-ÅÑŚÌβŁÈ/tests/integration/targets/firewalld/tasks/zone_default_test_cases.yml:7
Using module file /root/ansible_collections/ansible/posix/plugins/modules/firewalld.py
Pipelining is enabled.
<testhost> ESTABLISH LOCAL CONNECTION FOR USER: root
<testhost> EXEC /bin/sh -c '/usr/bin/python3.10 && sleep 0'
The full traceback is:
  File "/tmp/ansible_ansible.posix.firewalld_payload_t7hmnzkc/ansible_ansible.posix.firewalld_payload.zip/ansible_collections/ansible/posix/plugins/module_utils/firewalld.py", line 112, in action_handler
    return action_func(*action_func_args)
  File "/tmp/ansible_ansible.posix.firewalld_payload_t7hmnzkc/ansible_ansible.posix.firewalld_payload.zip/ansible_collections/ansible/posix/plugins/modules/firewalld.py", line 728, in set_enabled_permanent
  File "/usr/lib/python3.10/site-packages/firewall/client.py", line 50, in _impl
    return func(*args, **kwargs)
  File "/usr/lib/python3.10/site-packages/firewall/client.py", line 3257, in setDefaultZone
    self.fw.setDefaultZone(zone)
  File "/usr/lib64/python3.10/site-packages/dbus/proxies.py", line 141, in __call__
    return self._connection.call_blocking(self._named_service,
  File "/usr/lib64/python3.10/site-packages/dbus/connection.py", line 652, in call_blocking
    reply_message = self.send_message_with_reply_and_block(
fatal: [testhost]: FAILED! => {
    "changed": false,
    "invocation": {
        "module_args": {
            "default": true,
            "icmp_block": null,
            "icmp_block_inversion": null,
            "immediate": false,
            "interface": null,
            "masquerade": null,
            "offline": null,
            "permanent": true,
            "port": null,
            "port_forward": null,
            "rich_rule": null,
            "service": null,
            "source": null,
            "state": "enabled",
            "target": null,
            "timeout": 0,
            "zone": "trusted"
        }
    },
    "msg": "ERROR: Exception caught: org.fedoraproject.FirewallD1.Exception: COMMAND_FAILED: '{\"chain\": \"filter_INPUT_ZONES\", \"expr\": [{\"goto\": {\"target\": \"filter_IN_public\"}}], \"family\": \"inet\", \"table\": \"firewalld\"}' Permanent operation"
}
```