### PR TITLE
Modify firewalld port test cases to avoid port duplication on RHEL9.x

### DIFF
--- a/changelogs/fragments/407_fix_firewalld_port_test.yml
+++ b/changelogs/fragments/407_fix_firewalld_port_test.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- Fix firewalld port test cases to avoid port duplicatation.

--- a/tests/integration/targets/firewalld/tasks/port_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/port_test_cases.yml
@@ -4,7 +4,7 @@
 
 - name: firewalld port range test permanent enabled
   firewalld:
-    port: 5500-6950/tcp
+    port: 5500-6850/tcp
     permanent: true
     state: enabled
   register: result
@@ -16,7 +16,7 @@
 
 - name: firewalld port range test permanent enabled rerun (verify not changed)
   firewalld:
-    port: 5500-6950/tcp
+    port: 5500-6850/tcp
     permanent: true
     state: enabled
   register: result
@@ -57,7 +57,7 @@
     state: disabled
   loop:
     - 6900/tcp
-    - 5500-6950/tcp
+    - 5500-6850/tcp
 
 - name: firewalld port test permanent enabled
   firewalld:


### PR DESCRIPTION
##### SUMMARY

Modify firewalld port test cases to avoid port duplication behavior on RHEL9.x

##### ISSUE TYPE
- CI Tests Pull Request

##### COMPONENT NAME
- ansible.posix.firewalld

##### ADDITIONAL INFORMATION
- None