### PR TITLE
[CI] Update AZP CI matrix

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -53,8 +53,8 @@ stages:
           targets:
             - name: CentOS 7
               test: centos7
-            - name: Fedora 36
-              test: fedora36
+            - name: Fedora 37
+              test: fedora37
             - name: openSUSE 15 py3
               test: opensuse15
             - name: Ubuntu 20.04
@@ -209,10 +209,12 @@ stages:
               test: macos/12.0
             - name: RHEL 7.9
               test: rhel/7.9
-            - name: RHEL 8.6
-              test: rhel/8.6
-            - name: RHEL 9.0
-              test: rhel/9.0
+            - name: RHEL 8.7
+              test: rhel/8.7
+            - name: RHEL 9.1
+              test: rhel/9.1
+            - name: FreeBSD 12.4
+              test: freebsd/12.4
             - name: FreeBSD 13.1
               test: freebsd/13.1
   - stage: Remote_2_14
@@ -231,6 +233,8 @@ stages:
               test: rhel/8.6
             - name: RHEL 9.0
               test: rhel/9.0
+            - name: FreeBSD 12.3
+              test: freebsd/12.3
             - name: FreeBSD 13.1
               test: freebsd/13.1
   - stage: Remote_2_13

--- a/changelogs/fragments/409_update_azp_matrix.yml
+++ b/changelogs/fragments/409_update_azp_matrix.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - CI - Update AZP CI matrix (https://github.com/ansible-collections/ansible.posix/issues/408).


### PR DESCRIPTION
##### SUMMARY

To update AZP CI matrix for ansible-core devel branch to address the following issue:

- Fixes #408 
- Update Fedora36 with 37
- Update RHEL8.6 with 8.7
- Update RHEL9.0 with 9.1
- Update FreeBSD 12.3 with 12.4

##### ISSUE TYPE
- CI Tests Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
- Reference:  [ansible-test - new and deprecated platforms for testing #31 ](https://github.com/ansible-collections/news-for-maintainers/issues/31)
