### PR TITLE
Fix broken seealso in synchronize module

### DIFF
--- a/changelogs/fragments/413-synchronize-seealso.yml
+++ b/changelogs/fragments/413-synchronize-seealso.yml
@@ -1,0 +1,2 @@
+trivial:
+  - "synchronize - fix broken ``seealso`` module reference (https://github.com/ansible-collections/ansible.posix/pull/413)."

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -212,7 +212,7 @@ notes:
    - link_destination is subject to the same limitations as the underlying rsync daemon. Hard links are only preserved if the relative subtrees
      of the source and destination are the same. Attempts to hardlink into a directory that is a subdirectory of the source will be prevented.
 seealso:
-- module: copy
+- module: ansible.builtin.copy
 - module: community.windows.win_robocopy
 author:
 - Timothy Appnel (@tima)


### PR DESCRIPTION
##### SUMMARY
Module references must always have FQCN.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
synchronize
