### PR TITLE
patch: fix documentation syntax

### DIFF
--- a/changelogs/fragments/419-fix-patch-doc.yml
+++ b/changelogs/fragments/419-fix-patch-doc.yml
@@ -1,0 +1,2 @@
+trivial:
+  - patch - fix format syntax and boolean values on document (https://github.com/ansible-collections/ansible.posix/pull/419).

--- a/docs/ansible.posix.patch_module.rst
+++ b/docs/ansible.posix.patch_module.rst
@@ -84,9 +84,9 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Setting to <code>true</code> will disable patch&#x27;s heuristic for transforming CRLF line endings into LF.</div>
+                        <div>Setting to <code>yes</code> will disable patch&#x27;s heuristic for transforming CRLF line endings into LF.</div>
                         <div>Line endings of src and dest must match.</div>
-                        <div>If set to <code>false</code>, <code>patch</code> will replace CRLF in <code>src</code> files on POSIX.</div>
+                        <div>If set to <code>no</code>, <code>patch</code> will replace CRLF in <code>src</code> files on POSIX.</div>
                 </td>
             </tr>
             <tr>
@@ -122,7 +122,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Setting to <code>true</code> will ignore white space changes between patch and input.</div>
+                        <div>Setting to <code>yes</code> will ignore white space changes between patch and input..</div>
                 </td>
             </tr>
             <tr>
@@ -141,7 +141,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>If <code>false</code>, it will search for src at originating/controller machine, if <code>true</code> it will go to the remote/target machine for the <code>src</code>.</div>
+                        <div>If <code>no</code>, it will search for src at originating/controller machine, if <code>yes</code> it will go to the remote/target machine for the <code>src</code>.</div>
                 </td>
             </tr>
             <tr>
@@ -157,7 +157,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Path of the patch file as accepted by the GNU patch tool. If <code>remote_src</code> is <code>false</code>, the patch source file is looked up from the module&#x27;s <em>files</em> directory.</div>
+                        <div>Path of the patch file as accepted by the GNU patch tool. If <code>remote_src</code> is &#x27;no&#x27;, the patch source file is looked up from the module&#x27;s <em>files</em> directory.</div>
                         <div style="font-size: small; color: darkgreen"><br/>aliases: patchfile</div>
                 </td>
             </tr>

--- a/docs/ansible.posix.patch_module.rst
+++ b/docs/ansible.posix.patch_module.rst
@@ -84,9 +84,9 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Setting to <code>yes</code> will disable patch&#x27;s heuristic for transforming CRLF line endings into LF.</div>
+                        <div>Setting to <code>true</code> will disable patch&#x27;s heuristic for transforming CRLF line endings into LF.</div>
                         <div>Line endings of src and dest must match.</div>
-                        <div>If set to <code>no</code>, <code>patch</code> will replace CRLF in <code>src</code> files on POSIX.</div>
+                        <div>If set to <code>false</code>, <code>patch</code> will replace CRLF in <code>src</code> files on POSIX.</div>
                 </td>
             </tr>
             <tr>
@@ -122,7 +122,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Setting to <code>yes</code> will ignore white space changes between patch and input..</div>
+                        <div>Setting to <code>true</code> will ignore white space changes between patch and input.</div>
                 </td>
             </tr>
             <tr>
@@ -141,7 +141,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>If <code>no</code>, it will search for src at originating/controller machine, if <code>yes</code> it will go to the remote/target machine for the <code>src</code>.</div>
+                        <div>If <code>false</code>, it will search for src at originating/controller machine, if <code>true</code> it will go to the remote/target machine for the <code>src</code>.</div>
                 </td>
             </tr>
             <tr>
@@ -157,7 +157,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Path of the patch file as accepted by the GNU patch tool. If <code>remote_src</code> is &#x27;no&#x27;, the patch source file is looked up from the module&#x27;s <em>files</em> directory.</div>
+                        <div>Path of the patch file as accepted by the GNU patch tool. If <code>remote_src</code> is <code>false</code>, the patch source file is looked up from the module&#x27;s <em>files</em> directory.</div>
                         <div style="font-size: small; color: darkgreen"><br/>aliases: patchfile</div>
                 </td>
             </tr>

--- a/plugins/modules/patch.py
+++ b/plugins/modules/patch.py
@@ -37,7 +37,7 @@ options:
   src:
     description:
       - Path of the patch file as accepted by the GNU patch tool. If
-        C(remote_src) is 'no', the patch source file is looked up from the
+        C(remote_src) is C(false), the patch source file is looked up from the
         module's I(files) directory.
     type: path
     required: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixed lacking of `C()` for description of src option. And fixed by collection_prep.

Based on [this](https://docs.ansible.com/ansible/devel/dev_guide/developing_modules_documenting.html#linking-and-other-format-macros-within-module-documentation) and [this discussion](https://github.com/ansible-community/community-topics/issues/116).
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

- `ansible.posix.patch` module 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
N/A
```
