### PR TITLE
bindep - install rsync on all EL variants

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,4 +1,4 @@
 # This is a cross-platform list tracking distribution packages needed by tests;
 # see https://docs.openstack.org/infra/bindep/ for additional information.
 
-rsync [platform:rhel-8 platform:rhel-9]
+rsync [platform:redhat]


### PR DESCRIPTION
Adds support for installing rsync for centos and related EL variants (AlmaLinux, Rocky, Oracle, etc)

rsync is an extremely common package, available in the base repos of all EL distros.

This is necessary to properly support [AWX-EE](https://github.com/ansible/awx-ee) and other community-built EL Execution Environments.

See: https://github.com/ansible/awx-ee/issues/167