### PR TITLE
remove deprecated internal argument from synchronize

### DIFF
--- a/changelogs/fragments/421-remove-deprecation-warning.yml
+++ b/changelogs/fragments/421-remove-deprecation-warning.yml
@@ -1,0 +1,2 @@
+trivial:
+  - synchronize - instantiate the connection plugin without the ``new_stdin`` argument, which is deprecated in ansible-core 2.15 (https://github.com/ansible-collections/ansible.posix/pull/421).

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -284,9 +284,6 @@ class ActionModule(ActionBase):
         # told (via delegate_to) that a different host is the source of the
         # rsync
         if not use_delegate and remote_transport:
-            # Create a connection to localhost to run rsync on
-            new_stdin = self._connection._new_stdin
-
             # Unlike port, there can be only one shell
             localhost_shell = None
             for host in C.LOCALHOST:
@@ -315,7 +312,11 @@ class ActionModule(ActionBase):
                 localhost_executable = C.DEFAULT_EXECUTABLE
             self._play_context.executable = localhost_executable
 
-            new_connection = connection_loader.get('local', self._play_context, new_stdin)
+            try:
+                new_connection = connection_loader.get('local', self._play_context)
+            except TypeError:
+                # Needed for ansible-core < 2.15
+                new_connection = connection_loader.get('local', self._play_context, self._connection._new_stdin)
             self._connection = new_connection
             # Override _remote_is_local as an instance attribute specifically for the synchronize use case
             # ensuring we set local tmpdir correctly


### PR DESCRIPTION
##### SUMMARY
The connection's `_new_stdin` attribute has been deprecated in https://github.com/ansible/ansible/pull/79886. This plugin isn't actually using it for anything other than to instantiate a new connection (which isn't required as of the deprecation), so I just deleted it.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
synchronize.py
