### PR TITLE
firewalld_info: fixed typo in default_zone and improved examples

### DIFF
--- a/changelogs/fragments/426-firewalld_info-doc-update.yml
+++ b/changelogs/fragments/426-firewalld_info-doc-update.yml
@@ -1,0 +1,4 @@
+---
+
+trivial:
+  - firewalld_info - fixed typo in return value and improved examples in documentation

--- a/plugins/modules/firewalld_info.py
+++ b/plugins/modules/firewalld_info.py
@@ -37,6 +37,11 @@ EXAMPLES = r'''
 - name: Gather information about active zones
   ansible.posix.firewalld_info:
     active_zones: true
+  register: result
+
+- name: Print default zone for debugging
+  ansible.builtin.debug:
+    var: result.firewalld_info.default_zone
 
 - name: Gather information about specific zones
   ansible.posix.firewalld_info:
@@ -44,6 +49,7 @@ EXAMPLES = r'''
       - public
       - external
       - internal
+  register: result
 '''
 
 RETURN = r'''
@@ -78,7 +84,7 @@ firewalld_info:
             returned: success
             type: str
             sample: 0.8.2
-        default_zones:
+        default_zone:
             description:
               - The zone name of default zone.
             returned: success


### PR DESCRIPTION
##### SUMMARY

There was a typo in the docs of `firewalld_info`. Furthermore I slightly improved the examples by showcasing how to use the data gathered by this module. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
firewalld_info

##### ADDITIONAL INFORMATION

I'm not sure whether I should also update the file `docs/ansible.posix.firewalld_info_module.rst` but I suspect it will be generated automatically?
