### PR TITLE
synchronize: Allow user-defined --out-format

### DIFF
--- a/changelogs/fragments/428-synchronize-user-defined-out-format.yml
+++ b/changelogs/fragments/428-synchronize-user-defined-out-format.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - synchronize - user-defined ``--out-format`` in ``rsync_opts`` is now honored in the returned output. (https://github.com/ansible-collections/ansible.posix/pull/428)

--- a/changelogs/fragments/428-synchronize-user-definied-out-format.yml
+++ b/changelogs/fragments/428-synchronize-user-definied-out-format.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - synchronize - user-defined ``--out-format`` in ``rsync_opts`` is now honored in the returned output. (https://github.com/ansible-collections/ansible.posix/pull/428)

--- a/changelogs/fragments/428-synchronize-user-definied-out-format.yml
+++ b/changelogs/fragments/428-synchronize-user-definied-out-format.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - synchronize - user-defined ``--out-format`` in ``rsync_opts`` is now honored in the returned output. (https://github.com/ansible-collections/ansible.posix/pull/428)


### PR DESCRIPTION
##### SUMMARY
If the user specifes `--out-format` in the synchronize module's `rsync_opts` return the `msg` and `stdout_lines` fields in the requested format. When no `--out-format` is specified the default format for `--itemize-changes` (`%i %n%L`) is used.

When the module is called with `diff: true` the returned diff will remain in the default format for `--itemize-changes`.

This is a change from the current behaviour that always forces an output format of `%i %n%L` regardless of user-specified values for `--out-format`. This current behaviour was hard-coded in order to facilitate correctly setting the `changes` return value and having a fixed format for `diff: true`. I've endeavored to maintain the current behaviour for those purposes whilst additionally allowing user-defined formats.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
synchronize

##### ADDITIONAL INFORMATION
The generated `--out-format` attempts to combine:

- the user-requested `--out-format`
- a fixed marker to identify formatted output lines, `DIFF`
- the `%i` itemize-changes field
- the `%n%L` filename and link information fields (if we are returning a diff or if no format was specified)

seperated by a delimiter of `//`. No delimiter is completely safe for this purpose but I felt this one was sufficiently unlikely to appear the final three fields.

I didn't attempt to use field widths for parsing given I've seen `rsync` versions with different widths for the `%i` field. In fact this unreliability of the `%i` field (added to the fact that it can contain internal spaces making the default pattern, `%i %n%L`, also tricky to split on a delimiter) is the motivation for this change. I wanted to pass an `--out-format` of `{%-16i} %n` to synchronize to make programmatic parsing of the returned output easier but discovered that the module couldn't support it.

I've avoided the use of some more modern Python syntax (`str.removeprefix()`, `Match.__getitem__()`) because I'm developing against Python 2.7.18 and I imagine that I'm not alone in having to support old versions.