### PR TITLE
synchronize: use _find_needle instead

### DIFF
--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -48,10 +48,7 @@ class ActionModule(ActionBase):
         if ':' in path or path.startswith('/'):
             return path
 
-        if self._task._role is not None:
-            path = self._loader.path_dwim_relative(self._task._role._role_path, 'files', path)
-        else:
-            path = self._loader.path_dwim_relative(self._loader.get_basedir(), 'files', path)
+        path = self._find_needle('files', path)
 
         if original_path and original_path[-1] == '/' and path[-1] != '/':
             # make sure the dwim'd path ends in a trailing "/"


### PR DESCRIPTION
##### SUMMARY
It's not possible to use files from a sub role, this patch fixes this.

Fixes #381

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
synchornize

##### ADDITIONAL INFORMATION
See #381 