### PR TITLE
rhel_facts module must use keyword arguments

### DIFF
--- a/plugins/modules/rhel_facts.py
+++ b/plugins/modules/rhel_facts.py
@@ -69,7 +69,7 @@ def main():
     if os.path.exists("/run/ostree-booted"):
         ansible_facts['pkg_mgr'] = 'ansible.posix.rhel_rpm_ostree'
 
-    module.exit_json(ansible_facts, changed=False)
+    module.exit_json(ansible_facts=ansible_facts, changed=False)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The rhel_facts module must use keyword arguments.  The current
code gives this error:
```
Traceback (most recent call last):
...
  File "/tmp/ansible_ansible.posix.rhel_facts_payload_y10oy_4m/.../rhel_facts.py", line 72, in main
  TypeError: exit_json() takes 1 positional argument but 2 were given
```
The fix is to use all keyword arguments like other facts plugins.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
