### PR TITLE
json[l] callback: add play/task path info

### DIFF
--- a/changelogs/fragments/440-json-add-path-field.yaml
+++ b/changelogs/fragments/440-json-add-path-field.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - json and jsonl - Add the ``path`` attribute into the play and task output

--- a/plugins/callback/json.py
+++ b/plugins/callback/json.py
@@ -67,6 +67,7 @@ class CallbackModule(CallbackBase):
             'play': {
                 'name': play.get_name(),
                 'id': to_text(play._uuid),
+                'path': to_text(play.get_path()),
                 'duration': {
                     'start': current_time()
                 }
@@ -79,6 +80,7 @@ class CallbackModule(CallbackBase):
             'task': {
                 'name': task.get_name(),
                 'id': to_text(task._uuid),
+                'path': to_text(task.get_path()),
                 'duration': {
                     'start': current_time()
                 }

--- a/plugins/callback/jsonl.py
+++ b/plugins/callback/jsonl.py
@@ -69,6 +69,7 @@ class CallbackModule(CallbackBase):
             'play': {
                 'name': play.get_name(),
                 'id': to_text(play._uuid),
+                'path': to_text(play.get_path()),
                 'duration': {
                     'start': current_time()
                 }
@@ -81,6 +82,7 @@ class CallbackModule(CallbackBase):
             'task': {
                 'name': task.get_name(),
                 'id': to_text(task._uuid),
+                'path': to_text(task.get_path()),
                 'duration': {
                     'start': current_time()
                 }


### PR DESCRIPTION
Add the play and task path info (i.e., filename and line number) to the JSON that is emitted from the `json` and `jsonl` callback plugins, allowing more accurate post-mortem analysis.

##### SUMMARY
Add the play and task path info (i.e., filename and line number) to the JSON that is emitted from the `json` and `jsonl` callback plugins, allowing more accurate post-mortem analysis.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- ansible.posix.json
- ansible.posix.jsonl

##### ADDITIONAL INFORMATION
By also including the file/line number in the JSON data emitted, post-mortem analysis can unambiguously tie play/task log data to the specific play / task that generated it.  Without this information, it could be difficult for automated processes to precisely map log output back to the task that generated it (especially with playbooks that either do not name tasks, or do not name tasks uniquely).

Using this trivial playbook shows the change:

```yaml
- hosts: localhost
  gather_facts: false
  tasks:
    - name: hello, world
      debug:
        msg: hello, world
```

When using the `json` callback, here's what it looks like before the change (for brevity, just the `plays` section of the output):

```json
        {
            "play": {
                "duration": {
                    "end": "2023-04-08T11:35:39.694000Z",
                    "start": "2023-04-08T11:35:39.657056Z"
                },
                "id": "acde4800-1122-6387-7abd-000000000001",
                "name": "localhost",
            },
            "tasks": [
                {
                    "hosts": {
                        "localhost": {
                            "_ansible_no_log": null,
                            "_ansible_verbose_always": true,
                            "action": "debug",
                            "changed": false,
                            "msg": "hello, world"
                        }
                    },
                    "task": {
                        "duration": {
                            "end": "2023-04-08T11:35:39.694000Z",
                            "start": "2023-04-08T11:35:39.672132Z"
                        },
                        "id": "acde4800-1122-6387-7abd-000000000003",
                        "name": "hello, world",
                    }
                }
            ]
        }
```

After the change, there is a new `path` key/value in both the `play` and the `task`:

```json
        {
            "play": {
                "duration": {
                    "end": "2023-04-08T11:35:39.694000Z",
                    "start": "2023-04-08T11:35:39.657056Z"
                },
                "id": "acde4800-1122-6387-7abd-000000000001",
                "name": "localhost",
                "path": "/tmp/plays/hello.yaml:1"
            },
            "tasks": [
                {
                    "hosts": {
                        "localhost": {
                            "_ansible_no_log": null,
                            "_ansible_verbose_always": true,
                            "action": "debug",
                            "changed": false,
                            "msg": "hello, world"
                        }
                    },
                    "task": {
                        "duration": {
                            "end": "2023-04-08T11:35:39.694000Z",
                            "start": "2023-04-08T11:35:39.672132Z"
                        },
                        "id": "acde4800-1122-6387-7abd-000000000003",
                        "name": "hello, world",
                        "path": "/tmp/plays/hello.yaml:4"
                    }
                }
            ]
        }
```

The effect is the same in the `jsonl` plugin, but the output is squashed into a single line.