### PR TITLE
allowing synchronize to elevate permissions when sudo requires password entry - implements #334

### DIFF
--- a/changelogs/fragments/334_synchronize_using_become_pass.yml
+++ b/changelogs/fragments/334_synchronize_using_become_pass.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- synchronize - elevating privileges now works even when `sudo` requires entering the `become_pass`

--- a/docs/ansible.posix.synchronize_module.rst
+++ b/docs/ansible.posix.synchronize_module.rst
@@ -580,7 +580,7 @@ Notes
 
    - The user and permissions for the synchronize `dest` are those of the `remote_user` on the destination host or the `become_user` if `become=yes` is active.
    - In Ansible 2.0 a bug in the synchronize module made become occur on the "local host".  This was fixed in Ansible 2.0.1.
-   - Currently, synchronize is limited to elevating permissions via passwordless sudo.  This is because rsync itself is connecting to the remote machine and rsync doesn't give us a way to pass sudo credentials in.
+   - Currently, synchronize is limited to elevating permissions via sudo.  This now even works when password entry is required.
    - Currently there are only a few connection types which support synchronize (ssh, paramiko, local, and docker) because a sync strategy has been determined for those connection types.  Note that the connection for these must not need a password as rsync itself is making the connection and rsync does not provide us a way to pass a password to the connection.
    - Expect that dest=~/x will be ~<remote_user>/x even if using sudo.
    - Inspect the verbose output to validate the destination user/host/path are what was expected.

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -390,10 +390,24 @@ class ActionModule(ActionBase):
                 # If no rsync_path is set, become was originally set, and dest is
                 # remote then add privilege escalation here.
                 if self._play_context.become_method == 'sudo':
-                    if self._play_context.become_user:
-                        rsync_path = 'sudo -u %s rsync' % self._play_context.become_user
+                    
+                    # if become is set, we can either rely on passwordless sudo or pass the password
+                    if self._play_context.become_pass is None:
+                        rsync_path = 'sudo '
                     else:
-                        rsync_path = 'sudo rsync'
+                        # pass the become password using the environment so that the synchronize module
+                        # can wrap ssh on the host with a shell script that injects the password into
+                        # stdin, allowing for `sudo -S` on the target machine to retrieve the password
+                        if hasattr(self._task, 'environment'):
+                            self._task.environment = []
+                        self._task.environment.append({'BECOME_PASS': self._play_context.become_pass})
+                        _tmp_args['_ssh_wrapper'] = True
+                        rsync_path = 'sudo -S '
+                    
+                    if self._play_context.become_user:
+                        rsync_path += '-u %s rsync' % self._play_context.become_user
+                    else:
+                        rsync_path += 'rsync'
                 # TODO: have to add in the rest of the become methods here
 
             # We cannot use privilege escalation on the machine running the


### PR DESCRIPTION
This is a copy of #335 rebased against the current `main` branch so that it passes the CI checks.

See #335 for description and details.