### PR TITLE
fix firewalld protocol

### DIFF
--- a/changelogs/fragments/451_firewall_fix_protocol_parameter.yml
+++ b/changelogs/fragments/451_firewall_fix_protocol_parameter.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - firewall - Fix issue where opening a specific port resulted in opening the whole protocol of the specified port

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -858,10 +858,10 @@ def main():
 
     if module.params['port'] is not None:
         if '/' in module.params['port']:
-            port, protocol = module.params['port'].strip().split('/')
+            port, port_protocol = module.params['port'].strip().split('/')
         else:
-            protocol = None
-        if not protocol:
+            port_protocol = None
+        if not port_protocol:
             module.fail_json(msg='improper port format (missing protocol?)')
     else:
         port = None
@@ -981,7 +981,7 @@ def main():
 
         transaction = PortTransaction(
             module,
-            action_args=(port, protocol, timeout),
+            action_args=(port, port_protocol, timeout),
             zone=zone,
             desired_state=desired_state,
             permanent=permanent,
@@ -993,7 +993,7 @@ def main():
         if changed is True:
             msgs.append(
                 "Changed port %s to %s" % (
-                    "%s/%s" % (port, protocol), desired_state
+                    "%s/%s" % (port, port_protocol), desired_state
                 )
             )
 

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -864,7 +864,7 @@ def main():
         if not port_protocol:
             module.fail_json(msg='improper port format (missing protocol?)')
     else:
-        port = None
+        port_protocol = None
 
     port_forward_toaddr = ''
     port_forward = None

--- a/plugins/modules/firewalld.py
+++ b/plugins/modules/firewalld.py
@@ -856,6 +856,7 @@ def main():
     zone = module.params['zone']
     target = module.params['target']
 
+    port = None
     if module.params['port'] is not None:
         if '/' in module.params['port']:
             port, port_protocol = module.params['port'].strip().split('/')


### PR DESCRIPTION
##### SUMMARY

This PR resolves an issue where opening a port (e.g. `25/tcp`) resulted in opening all ports for the specified protocol (e.g. `tcp`)

Fixes https://github.com/ansible-collections/ansible.posix/issues/451

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ansible.posix.firewalld

##### ADDITIONAL INFORMATION

Many thanks to @nerrehmit and every one else who helped troubleshooting this!
