### PR TITLE
fix sysctl integration test failing on newer versions of core

### DIFF
--- a/changelogs/fragments/456_sysctl_fix_nonetype.yml
+++ b/changelogs/fragments/456_sysctl_fix_nonetype.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Fix sysctl integration test failing on newer versions of core. Previously NoneType was allowable, now it fails to convert to a str type."

--- a/tests/integration/targets/sysctl/tasks/main.yml
+++ b/tests/integration/targets/sysctl/tasks/main.yml
@@ -170,7 +170,7 @@
 
     - name: Try sysctl with no name
       sysctl:
-        name:
+        name: ""
         value: 1
         sysctl_set: yes
       ignore_errors: True
@@ -180,7 +180,7 @@
       assert:
         that:
           - sysctl_no_name is failed
-          - "sysctl_no_name.msg == 'name cannot be None'"
+          - "sysctl_no_name.msg == 'name cannot be blank'"
 
     - name: Try sysctl with no value
       sysctl:


### PR DESCRIPTION
Previously NoneType was allowable, now it fails to convert to a str type.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
    fix sysctl integration test failing on newer versions of core

    Previously NoneType was allowable, now it fails to convert to a str
    type.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
sysctl

