### PR TITLE
Fix CI: replace `include:` with `include_tasks:`

### DIFF
--- a/changelogs/fragments/466-tests.yml
+++ b/changelogs/fragments/466-tests.yml
@@ -1,0 +1,2 @@
+trivial:
+  - "Fix integration tests so they work with ansible-core devel / 2.16 (https://github.com/ansible-collections/ansible.posix/pull/466)."

--- a/tests/integration/targets/acl/tasks/main.yml
+++ b/tests/integration/targets/acl/tasks/main.yml
@@ -17,7 +17,7 @@
 
 - block:
 
-  - include: acl.yml
+  - include_tasks: acl.yml
     when: ansible_system == 'Linux'  # TODO enable acls mount option on FreeBSD to test it there too
 
   always:

--- a/tests/integration/targets/seboolean/tasks/main.yml
+++ b/tests/integration/targets/seboolean/tasks/main.yml
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- include: seboolean.yml
+- include_tasks: seboolean.yml
   when:
     - ansible_selinux is defined
     - ansible_selinux != False

--- a/tests/integration/targets/selinux/tasks/main.yml
+++ b/tests/integration/targets/selinux/tasks/main.yml
@@ -23,13 +23,13 @@
     msg: SELinux is {{ ansible_selinux.status }}
   when: ansible_selinux is defined and ansible_selinux != False
 
-- include: selinux.yml
+- include_tasks: selinux.yml
   when:
     - ansible_selinux is defined
     - ansible_selinux != False
     - ansible_selinux.status == 'enabled'
 
-- include: selogin.yml
+- include_tasks: selogin.yml
   when:
     - ansible_selinux is defined
     - ansible_selinux != False


### PR DESCRIPTION
##### SUMMARY
`include:` is removed for ansible-core 2.16 and no longer works with current devel.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
integration tests
