### PR TITLE
Fix CI: Remove FreeBSD 12.2 targets

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -293,8 +293,6 @@ stages:
               test: rhel/7.9
             - name: RHEL 8.4
               test: rhel/8.4
-            - name: FreeBSD 12.2
-              test: freebsd/12.2
             - name: FreeBSD 13.0
               test: freebsd/13.0
   - stage: Remote_2_11
@@ -311,8 +309,6 @@ stages:
               test: rhel/7.9
             - name: RHEL 8.3
               test: rhel/8.3
-            - name: FreeBSD 12.2
-              test: freebsd/12.2
   - stage: Remote_2_10
     displayName: Remote 2.10
     dependsOn: []


### PR DESCRIPTION
##### SUMMARY
Removes CI tests for FreeBSD 12.2 that are failing when trying to bootstrap http://pkg.freebsd.org/FreeBSD:12:amd64/release_2

Example PR affected https://github.com/ansible-collections/ansible.posix/pull/466

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.azure-pipelines/azure-pipelines.yml

##### ADDITIONAL INFORMATION
N/A
