### PR TITLE
firewalld: make offline do something

### DIFF
--- a/changelogs/fragments/484-firewalld-offline.yml
+++ b/changelogs/fragments/484-firewalld-offline.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - firewalld - added offline flag implementation (https://github.com/ansible-collections/ansible.posix/pull/484)

--- a/tests/integration/targets/firewalld/tasks/service_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/service_test_cases.yml
@@ -20,6 +20,8 @@
   firewalld:
     service: https
     permanent: true
+    immediate: true
+    offline: true
     state: enabled
   register: result
 
@@ -32,6 +34,8 @@
   firewalld:
     service: https
     permanent: true
+    immediate: true
+    offline: true
     state: enabled
   register: result
 
@@ -44,6 +48,8 @@
   firewalld:
     service: https
     permanent: true
+    immediate: true
+    offline: true
     state: disabled
   register: result
 
@@ -56,6 +62,8 @@
   firewalld:
     service: https
     permanent: true
+    immediate: true
+    offline: true
     state: disabled
   register: result
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`ansible.posix.firewalld` has an `offline` flag, but it currently does not do anything. What most people expect it to do is allow the task to proceed even when `firewalld` is offline, so it makes the most sense for it to override the `immediate` flag and prevent the module from throwing an error in that case.

Fixes #81.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
firewalld

##### ADDITIONAL INFORMATION