### PR TITLE
Docs/authorized_key: clarify that the path key should probably NOT be set

### DIFF
--- a/changelogs/fragments/490_doc_authorized_key_path.yml
+++ b/changelogs/fragments/490_doc_authorized_key_path.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "Bugfix in the documentation regarding the path option for authorised_key(https://github.com/ansible-collections/ansible.posix/issues/483)."

--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -28,8 +28,10 @@ options:
     required: true
   path:
     description:
-      - Alternate path to the authorized_keys file.
-      - When unset, this value defaults to I(~/.ssh/authorized_keys).
+      - Alternative path to the authorized_keys file.
+      - The default value is the C(.ssh/authorized_keys) of the home of the user specified in the O(user) parameter.
+      - Most of the time, it's not necessary to set this key.
+      - Use the path to your target authorized_keys if you need to explicitly point on it.
     type: path
   manage_dir:
     description:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Docs: Fixed unclearance in documentation connected wirh relative path

Added additional description in documentation.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
authorized_key.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
Clarify the documentation unclearance in connected with relative path `~/.ssh/authorized_keys`
The purpose of the pull request is to eliminate ambiguities in the documentation.
In our case, when using the ~ sign, we get the user's root directory (although we explicitly specify a different username)
Here is the issue and full picture of problem which we want to fix: [LINK](https://github.com/ansible-collections/ansible.posix/issues/483)
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->


Closese:  #483