### PR TITLE
seboolean: make it work with disabled SELinux

### DIFF
--- a/changelogs/fragments/496_seboolean-make-it-wrk-with-SELinux-disabled.yaml
+++ b/changelogs/fragments/496_seboolean-make-it-wrk-with-SELinux-disabled.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - seboolean - make it work with disabled SELinux

--- a/plugins/modules/seboolean.py
+++ b/plugins/modules/seboolean.py
@@ -73,30 +73,12 @@ except ImportError:
     HAVE_SEMANAGE = False
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils.six import binary_type
-from ansible.module_utils._text import to_bytes, to_text
+from ansible.module_utils._text import to_text
 from ansible_collections.ansible.posix.plugins.module_utils._respawn import respawn_module, HAS_RESPAWN_UTIL
 
 
 def get_runtime_status(ignore_selinux_state=False):
     return True if ignore_selinux_state is True else selinux.is_selinux_enabled()
-
-
-def has_boolean_value(module, name):
-    bools = []
-    try:
-        rc, bools = selinux.security_get_boolean_names()
-    except OSError:
-        module.fail_json(msg="Failed to get list of boolean names")
-    # work around for selinux who changed its API, see
-    # https://github.com/ansible/ansible/issues/25651
-    if len(bools) > 0:
-        if isinstance(bools[0], binary_type):
-            name = to_bytes(name)
-    if name in bools:
-        return True
-    else:
-        return False
 
 
 def get_boolean_value(module, name):
@@ -174,7 +156,10 @@ def semanage_set_boolean_value(module, handle, name, value):
         semanage.semanage_handle_destroy(handle)
         module.fail_json(msg="Failed to modify boolean key with semanage")
 
-    if semanage.semanage_bool_set_active(handle, boolkey, sebool) < 0:
+    if (
+            selinux.is_selinux_enabled()
+            and semanage.semanage_bool_set_active(handle, boolkey, sebool) < 0
+    ):
         semanage.semanage_handle_destroy(handle)
         module.fail_json(msg="Failed to set boolean key active with semanage")
 
@@ -315,12 +300,9 @@ def main():
         # Feature only available in selinux library since 2012.
         name = selinux.selinux_boolean_sub(name)
 
-    if not has_boolean_value(module, name):
-        module.fail_json(msg="SELinux boolean %s does not exist." % name)
-
     if persistent:
         changed = semanage_boolean_value(module, name, state)
-    else:
+    elif selinux.is_selinux_enabled():
         cur_value = get_boolean_value(module, name)
         if cur_value != state:
             changed = True


### PR DESCRIPTION
##### SUMMARY

Sometimes it's necessary to configure SELinux before it's enabled on the system. There's `ignore_selinux_state` which should allow it. Before this change `seboolean` module failed on SELinux disabled system even with `ignore_selinux_state: true` and SELinux policy installed while `semanage boolean` worked as expected:

    $ ansible -i 192.168.121.153, -m seboolean -a "name=ssh_sysadm_login state=on ignore_selinux_state=true" all
    192.168.121.153 | FAILED! => {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python3"
        },
        "changed": false,
        "msg": "Failed to get list of boolean names"
    }

    $ ssh root@192.168.121.153 semanage boolean -l | grep ssh_sysadm_login
    ssh_sysadm_login               (off  ,  off)  Allow ssh to sysadm login

It's caused by `selinux.security_get_boolean_names()` and `selinux.security_get_boolean_active(name)` which required SELinux enabled system.

This change adds a fallback to semanage API which works in SELinux disabled system when SELinux targeted policy is installed:

    ANSIBLE_LIBRARY=plugins/modules ansible -i 192.168.121.153, -m seboolean -a "name=ssh_sysadm_login state=on persistent=true ignore_selinux_state=true" all
    192.168.121.153 | CHANGED => {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python3"
        },
        "changed": true,
        "name": "ssh_sysadm_login",
        "persistent": true,
        "state": true
    }

    $ ssh root@192.168.121.153 semanage boolean -l | grep ssh_sysadm_login
    ssh_sysadm_login               (on   ,   on)  Allow ssh to sysadm login

Note that without `persistent=true` this module is effectively NO-OP now.



##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
seboolean

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Before:

```
    $ ansible -i 192.168.121.153, -m seboolean -a "name=ssh_sysadm_login state=on ignore_selinux_state=true" all
    192.168.121.153 | FAILED! => {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python3"
        },
        "changed": false,
        "msg": "Failed to get list of boolean names"
    }

    $ ssh root@192.168.121.153 semanage boolean -l | grep ssh_sysadm_login
    ssh_sysadm_login               (off  ,  off)  Allow ssh to sysadm login
```
After:

```
    $ ansible -i 192.168.121.153, -m seboolean -a "name=ssh_sysadm_login state=on persistent=true ignore_selinux_state=true" all
    192.168.121.153 | CHANGED => {
        "ansible_facts": {
            "discovered_interpreter_python": "/usr/bin/python3"
        },
        "changed": true,
        "name": "ssh_sysadm_login",
        "persistent": true,
        "state": true
    }

    $ ssh root@192.168.121.153 semanage boolean -l | grep ssh_sysadm_login
    ssh_sysadm_login               (on   ,   on)  Allow ssh to sysadm login
```