### PR TITLE
Warn only when zones were ignored in firewalld_info

### DIFF
--- a/changelogs/fragments/504-firewalld_info-warning.yaml
+++ b/changelogs/fragments/504-firewalld_info-warning.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - firewalld_info - Only warn about ignored zones, when there are zones ignored.

--- a/plugins/modules/firewalld_info.py
+++ b/plugins/modules/firewalld_info.py
@@ -356,8 +356,9 @@ def main():
             specified_zones = module.params['zones']
             collect_zones = list(set(specified_zones) & set(all_zones))
             ignore_zones = list(set(specified_zones) - set(collect_zones))
-            warn.append(
-                'Please note: zone:(%s) have been ignored in the gathering process.' % ','.join(ignore_zones))
+            if ignore_zones:
+                warn.append(
+                    'Please note: zone:(%s) have been ignored in the gathering process.' % ','.join(ignore_zones))
         else:
             collect_zones = get_all_zones(client)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

When using the `ansible.posix.firewalld_info` module with given `zones:` a warning about ignored zones is thrown, even no zones were ignored

task
```yaml
- name: fetch current info about zone '{{ fw_zone.name }}'
  ansible.posix.firewalld_info:
    zones:
      - '{{ fw_zone.name }}'
  register: fw_zone_info
```

output
```
[...]
TASK [firewalld : fetch current info about zone 'public'] *********************************************************************************************************
[WARNING]: Please note: zone:() have been ignored in the gathering process.
[...]
```

With this change, the warning is only shown, when zones were ignored.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
firewalld_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
