### PR TITLE
[CI] Replace Fedora 38 with 39 for devel branch container test

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -51,8 +51,8 @@ stages:
         parameters:
           testFormat: devel/linux/{0}/1
           targets:
-            - name: Fedora 38
-              test: fedora38
+            - name: Fedora 39
+              test: fedora39
             - name: Ubuntu 20.04
               test: ubuntu2004
             - name: Ubuntu 22.04

--- a/changelogs/fragments/510_ci_update.yml
+++ b/changelogs/fragments/510_ci_update.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "Replace Fedora 38 with 39 for container test(https://github.com/ansible-collections/ansible.posix/issues/509)."


### PR DESCRIPTION
##### SUMMARY

Replace Fedora 38 container test with 39 for devel branch.


- Fixed /#509

##### ISSUE TYPE
- CI test Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
None
