### PR TITLE
update ci target for freebsd 13, r1 is eol

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -209,8 +209,8 @@ stages:
               test: rhel/8.7
             - name: RHEL 9.1
               test: rhel/9.1
-            - name: FreeBSD 13.1
-              test: freebsd/13.1
+            - name: FreeBSD 13.2
+              test: freebsd/13.2
             - name: FreeBSD 12.4
               test: freebsd/12.4
   - stage: Remote_2_14
@@ -225,8 +225,8 @@ stages:
               test: rhel/7.9
             - name: RHEL 8.6
               test: rhel/8.6
-            - name: FreeBSD 13.1
-              test: freebsd/13.1
+            - name: FreeBSD 13.2
+              test: freebsd/13.2
             - name: FreeBSD 12.4
               test: freebsd/12.4
 


### PR DESCRIPTION
Current CI fails due to the  release_1/ dir returning 404, this will move to working release_2/ dir

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
CI
