### PR TITLE
Fix Synchronize Not Sourcing Multiple Paths

### DIFF
--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -331,6 +331,8 @@ class ActionModule(ActionBase):
         dest = _tmp_args.get('dest', None)
         if src is None or dest is None:
             return dict(failed=True, msg="synchronize requires both src and dest parameters are set")
+        if isinstance(src, str):
+            src = [src]
 
         # Determine if we need a user@ and a password
         user = None
@@ -357,11 +359,11 @@ class ActionModule(ActionBase):
             # use the mode to define src and dest's url
             if _tmp_args.get('mode', 'push') == 'pull':
                 # src is a remote path: <user>@<host>, dest is a local path
-                src = self._process_remote(_tmp_args, src_host, src, user, inv_port in localhost_ports)
+                src = [self._process_remote(_tmp_args, src_host, e, user, inv_port in localhost_ports) for e in src]
                 dest = self._process_origin(dest_host, dest, user)
             else:
                 # src is a local path, dest is a remote path: <user>@<host>
-                src = self._process_origin(src_host, src, user)
+                src = [self._process_origin(src_host, e, user) for e in src]
                 dest = self._process_remote(_tmp_args, dest_host, dest, user, inv_port in localhost_ports)
 
             password = dest_host_inventory_vars.get('ansible_ssh_pass', None) or dest_host_inventory_vars.get('ansible_password', None)
@@ -370,7 +372,7 @@ class ActionModule(ActionBase):
         else:
             # Still need to munge paths (to account for roles) even if we aren't
             # copying files between hosts
-            src = self._get_absolute_path(path=src)
+            src = [self._get_absolute_path(path=e) for e in src]
             dest = self._get_absolute_path(path=dest)
 
         _tmp_args['_local_rsync_password'] = password

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -395,9 +395,9 @@ def substitute_controller(path):
 
 
 def is_rsh_needed(source, dest):
-    if source.startswith('rsync://') or dest.startswith('rsync://'):
+    if all(e.startswith('rsync://') for e in source) or dest.startswith('rsync://'):
         return False
-    if ':' in source or ':' in dest:
+    if any(':' in e for e in source) or ':' in dest:
         return True
     return False
 
@@ -405,7 +405,7 @@ def is_rsh_needed(source, dest):
 def main():
     module = AnsibleModule(
         argument_spec=dict(
-            src=dict(type='path', required=True),
+            src=dict(type='list', required=True),
             dest=dict(type='path', required=True),
             dest_port=dict(type='int'),
             delete=dict(type='bool', default=False),
@@ -539,11 +539,10 @@ def main():
     if dirs:
         cmd.append('--dirs')
 
-    if source.startswith('rsync://') and dest.startswith('rsync://'):
+    if all(e.startswith('rsync://') for e in source) and dest.startswith('rsync://'):
         module.fail_json(msg='either src or dest must be a localhost', rc=1)
 
     if is_rsh_needed(source, dest):
-
         # https://github.com/ansible/ansible/issues/15907
         has_rsh = False
         for rsync_opt in rsync_opts:
@@ -599,7 +598,7 @@ def main():
     changed_marker = '<<CHANGED>>'
     cmd.append('--out-format=%s' % shlex_quote(changed_marker + '%i %n%L'))
 
-    cmd.append(shlex_quote(source))
+    [cmd.append(shlex_quote(e)) for e in source]
     cmd.append(shlex_quote(dest))
     cmdstr = ' '.join(cmd)
 

--- a/plugins/modules/synchronize.py
+++ b/plugins/modules/synchronize.py
@@ -360,6 +360,17 @@ EXAMPLES = r'''
         src: /tmp/localpath/
         dest: /tmp/remotepath
         rsync_path: /usr/gnu/bin/rsync
+
+# Source files from multiple folders and merge them on the remote
+# Files of the same name in /tmp/path_c/ will take precedence over those in /tmp/path_b/, and same for path_b to path_a
+- name: Copy files from multiple folders and merge them into dest
+  ansible.posix.synchronize:
+    src: 
+    - /tmp/path_a/
+    - /tmp/path_b/
+    - /tmp/path_c/
+    dest: /tmp/dest/
+    recursive: True
 '''
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
rsync supports sourcing files from multiple paths simply by specifying multiple paths on the command line. When the paths are folders, the same files in subsequent paths will take precedence over those in previous paths. This is often used to "merge" multiple local folders onto a remote.

For example, if this is the folder structure on the local machine and we are copying to `/tmp/dest` on the remote machine
```
tmp
├── path_a
│   ├── file1
│   └── file2
├── path_b
│   ├── file2
│   ├── file3
│   └── file4
├── path_c
│   ├── file2
│   └── file5
```
The result would be
```
tmp
├── dest
│   ├── file1 ...with data from path_a
│   ├── file2 ...from path_c
│   ├── file3.php ...path_b
│   ├── file4.php ...from path_b
│   └── file5.php ...from path_c
```

The syntax to do this in ansible is now as follows:
```
- name: Copy files from multiple folders and merge them into dest
  ansible.posix.synchronize:
    src: 
    - /tmp/path_a/
    - /tmp/path_b/
    - /tmp/path_c/
    dest: /tmp/dest/
    recursive: True
```

My primary use case for this is having a set of files stored in `host_vars`, `group_vars`, and `all` which should be copied over to the remote with files from `host_vars` superseding `group_vars` and `group_vars` superseding all.
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
synchronize

##### ADDITIONAL INFORMATION
This does not replace specifying a singular path with a string, that still works and thus backwards compatibility is preserved.

The only change this has for existing codebases on end users is in the -vvv debug output and in the invocation args of the variable returned by `register:`. Specifically `var.invocation.module_args.src` on synchronize tasks will return a list with 1 entry being the path instead of just the entry, which is unlikely to cause any breakage. If this change in output is unacceptable though, I can spend the effort to modify the modules to use strings and splitting to prevent this.