### PR TITLE
mount: edit boot parameters warning condition

### DIFF
--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -831,7 +831,7 @@ def main():
         # handle mount on boot.  To avoid mount option conflicts, if 'noauto'
         # specified in 'opts',  mount module will ignore 'boot'.
         opts = args['opts'].split(',')
-        if 'noauto' in opts:
+        if module.params['boot'] and 'noauto' in opts:
             args['warnings'].append("Ignore the 'boot' due to 'opts' contains 'noauto'.")
         elif not module.params['boot']:
             args['boot'] = 'no'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
I have modified warning conditions when using opts parameter with `noauto` value. Now it doesn't give unnecessary warning when user doesn't have used boot parameter. It will now check that if boot parameter is true and opts parameter has `noauto`. One alternative is to check if boot is defined instead. But in case boot is false there is no need to give warning because noauto is same as boot false.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #522

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mount

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
