### PR TITLE
Fix CI issues

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -211,8 +211,6 @@ stages:
               test: rhel/9.1
             - name: FreeBSD 13.2
               test: freebsd/13.2
-            - name: FreeBSD 12.4
-              test: freebsd/12.4
   - stage: Remote_2_14
     displayName: Remote 2.14
     dependsOn: []
@@ -227,8 +225,6 @@ stages:
               test: rhel/8.6
             - name: FreeBSD 13.2
               test: freebsd/13.2
-            - name: FreeBSD 12.4
-              test: freebsd/12.4
 
   ## Finally
 

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -62,16 +62,7 @@ else
     retry pip install "https://github.com/ansible/ansible/archive/stable-${ansible_version}.tar.gz" --disable-pip-version-check
 fi
 
-if [ "${SHIPPABLE_BUILD_ID:-}" ]; then
-    export ANSIBLE_COLLECTIONS_PATHS="${HOME}/.ansible"
-    SHIPPABLE_RESULT_DIR="$(pwd)/shippable"
-    TEST_DIR="${ANSIBLE_COLLECTIONS_PATHS}/ansible_collections/ansible/posix"
-    mkdir -p "${TEST_DIR}"
-    cp -aT "${SHIPPABLE_BUILD_DIR}" "${TEST_DIR}"
-    cd "${TEST_DIR}"
-else
-    export ANSIBLE_COLLECTIONS_PATHS="${PWD}/../../../"
-fi
+export ANSIBLE_COLLECTIONS_PATHS="${PWD}/../../../"
 
 # START: HACK install dependencies
 if [ "${ansible_version}" == "2.9" ] || [ "${ansible_version}" == "2.10" ]; then


### PR DESCRIPTION
##### SUMMARY
- Sanity tests fail; remove problematic Shippable-specific parts of shippable.sh script.
- FreeBSD 12.4 have apparently been removed also from older versions of ansible-test.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
