### PR TITLE
ci: replace freebsd 13.2 with 13.3

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -178,8 +178,8 @@ stages:
           targets:
             - name: RHEL 9.3
               test: rhel/9.3
-            - name: FreeBSD 13.2
-              test: freebsd/13.2
+            - name: FreeBSD 13.3
+              test: freebsd/13.3
   - stage: Remote_2_16
     displayName: Remote 2.16
     dependsOn: []


### PR DESCRIPTION
The devel version of ansible-test has been updated to include support for FreeBSD 13.3, so this change swaps out 13.2 accordingly.

See https://github.com/ansible-collections/news-for-maintainers/issues/67