### PR TITLE
Add Support for `--system` Option in Sysctl Module

### DIFF
--- a/plugins/modules/sysctl.py
+++ b/plugins/modules/sysctl.py
@@ -114,12 +114,24 @@ class SysctlModule(object):
     # success or failure.
     LANG_ENV = {'LANG': 'C', 'LC_ALL': 'C', 'LC_MESSAGES': 'C'}
 
+    # We define a variable to keep all the directories to be read, equivalent to
+    # (/sbin/sysctl --system) option
+    SYSCTL_DIRS = [
+        '/etc/sysctl.d/*.conf',
+        '/run/sysctl.d/*.conf',
+        '/usr/local/lib/sysctl.d/*.conf',
+        '/usr/lib/sysctl.d/*.conf',
+        '/lib/sysctl.d/*.conf',
+        '/etc/sysctl.conf'
+    ]
+
     def __init__(self, module):
         self.module = module
         self.args = self.module.params
 
         self.sysctl_cmd = self.module.get_bin_path('sysctl', required=True)
         self.sysctl_file = self.args['sysctl_file']
+        self.system_Wide = self.args['system_Wide']
 
         self.proc_value = None  # current token value in proc fs
         self.file_value = None  # current token value in file

--- a/plugins/modules/sysctl.py
+++ b/plugins/modules/sysctl.py
@@ -386,27 +386,15 @@ class SysctlModule(object):
     # Completely rewrite the sysctl file
     def write_sysctl(self):
         # open a tmp file
-        if self.system_Wide:
-            sysctl_files_dir = '/etc/sysctl.d/'
-            fd, tmp_path = tempfile.mkstemp('.conf', '.ansible_m_sysctl_', sysctl_files_dir)
-            os.close(fd=fd)
-        else:
-            fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(self.sysctl_file))
-            os.close(fd)
-        
+        fd, tmp_path = tempfile.mkstemp('.conf', '.ansible_m_sysctl_', os.path.dirname(os.path.realpath(self.sysctl_file)))
+        f = open(tmp_path, "w")
         try:
-            with open(tmp_path, 'w') as write_file:
-                for line in self.fixed_lines:
-                    write_file.write("%s\n" % line)
-            os.rename(tmp_path, self.sysctl_file)
+            for l in self.fixed_lines:
+                f.write(l.strip() + "\n")
         except IOError as e:
-            self.module.fail_json(msg="Failed to write %s: %s" % (to_native(tmp_path), to_native(e)))
-        finally:
-            try:
-                os.remove(tmp_path)
-            except OSError:
-                pass
-
+            self.module.fail_json(msg="Failed to write to file %s: %s" % (tmp_path, to_native(e)))
+        f.flush()
+        f.close()
 
         # replace the real one
         self.module.atomic_move(tmp_path, os.path.realpath(self.sysctl_file))


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Sysctl module does not currently support the `--system` option, which loads the configuration files from directories in the following order.
`/etc/sysctl.d/*.conf`
`/run/sysctl.d/*.conf`
`/usr/local/lib/sysctl.d/*.conf`
`/usr/lib/sysctl.d/*.conf`
`/lib/sysctl.d/*.conf`
`/etc/sysctl.conf`

I defined `SYSCTL_DIRS`, list of directories to iterate over if `system_wide` parameter is set to true. It acts same as `sysctl -p <config-file>`, and goes over all the paths defined in `SYSCTL_DIRS`.
Fixes #512 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ansible.posix.sysctl

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
