### PR TITLE
Add basic ansible-lint config to fix CI; add ansible-core 2.17 to CI

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,10 @@
+---
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2024, Ansible Project
+
+skip_list:
+  - meta-runtime[unsupported-version]  # Tis rule doesn't make any sense
+  - fqcn[deep]  # This rule produces false positives for files in tests/unit/plugins/action/fixtures/
+exclude_paths:
+  - changelogs/

--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -57,6 +57,21 @@ stages:
               test: units
             - name: Lint
               test: lint
+  - stage: Sanity_2_17
+    displayName: Ansible 2.17 sanity
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: "{0}"
+          testFormat: 2.17/{0}
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
+            - name: Lint
+              test: lint
   - stage: Sanity_2_16
     displayName: Ansible 2.16 sanity
     dependsOn: []
@@ -70,8 +85,6 @@ stages:
               test: sanity
             - name: Units
               test: units
-            - name: Lint
-              test: lint
   - stage: Sanity_2_15
     displayName: Ansible 2.15 sanity
     dependsOn: []
@@ -106,6 +119,20 @@ stages:
       - template: templates/matrix.yml
         parameters:
           testFormat: devel/linux/{0}/1
+          targets:
+            - name: Fedora 39
+              test: fedora39
+            - name: Ubuntu 20.04
+              test: ubuntu2004
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+  - stage: Docker_2_17
+    displayName: Docker 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.17/linux/{0}/1
           targets:
             - name: Fedora 39
               test: fedora39
@@ -180,6 +207,18 @@ stages:
               test: rhel/9.3
             - name: FreeBSD 13.3
               test: freebsd/13.3
+  - stage: Remote_2_17
+    displayName: Remote 2.17
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.17/{0}/1
+          targets:
+            - name: RHEL 9.3
+              test: rhel/9.3
+            - name: FreeBSD 13.3
+              test: freebsd/13.3
   - stage: Remote_2_16
     displayName: Remote 2.16
     dependsOn: []
@@ -240,6 +279,9 @@ stages:
       - Sanity_2_16
       - Remote_2_16
       - Docker_2_16
+      - Sanity_2_17
+      - Remote_2_17
+      - Docker_2_17
       - Sanity_devel
       - Remote_devel
       - Docker_devel

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,1 @@
+tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY
ansible-lint makes the nightly CI fail (https://dev.azure.com/ansible/ansible.posix/_build/results?buildId=114105&view=logs&j=2671e6a6-f41a-533c-2720-8ffdcf8ab96f&t=5b604a49-baaa-558f-6ab2-4a2ff646af4f) due to two rules:
- `meta-runtime[unsupported-version]`: it doesn't like that the collection supports ansible-core versions that are EOL. This rule simply doesn't make any sense, and it should be disabled by default IMO.
- `fqcn[deep]`: this rule produces false positives for files in `tests/unit/plugins/action/fixtures/`.

Also adds sanity ignore file for ansible-core 2.18 (the version used by the current `devel` branch).

##### ISSUE TYPE
- Bugfix Pull Request
- Test Pull Request

##### COMPONENT NAME
ansible-lint in CI
