### PR TITLE
Firewalld: Add functionality to set forwarding

### DIFF
--- a/changelogs/fragments/548_add_foward.yml
+++ b/changelogs/fragments/548_add_foward.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - firewalld - add functionality to set forwarding (https://github.com/ansible-collections/ansible.posix/pull/548).

--- a/tests/integration/targets/firewalld/tasks/source_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/source_test_cases.yml
@@ -83,5 +83,6 @@
   ansible.builtin.assert:
     that:
       - result is not changed
-      - "result.msg ==
-        'parameters are mutually exclusive: icmp_block|icmp_block_inversion|service|protocol|port|port_forward|rich_rule|interface|masquerade|source|target'"
+      - >
+        result.msg == 'parameters are mutually exclusive:
+        icmp_block|icmp_block_inversion|service|protocol|port|port_forward|rich_rule|interface|forward|masquerade|source|target'

--- a/tests/integration/targets/firewalld/tasks/zone_test_cases.yml
+++ b/tests/integration/targets/firewalld/tasks/zone_test_cases.yml
@@ -23,6 +23,55 @@
     that:
       - result is not changed
 
+- name: Zone forwarding test
+  when: (ansible_distribution == 'RedHat' and ansible_distribution_major_version is version('8', '>='))
+  block:
+    - name: Enable zone forwarding
+      ansible.posix.firewalld:
+        zone: custom
+        forward: true
+        permanent: true
+        state: enabled
+      register: result
+
+    - name: Assert zone forwarding is enabled
+      ansible.builtin.debug:
+        var: result is changed
+
+    - name: Enable zone forwarding (verify not changed)
+      ansible.posix.firewalld:
+        zone: custom
+        forward: true
+        permanent: true
+        state: enabled
+      register: result
+
+    - name: Assert zone forwarding is enabled (verify not changed)
+      ansible.builtin.debug:
+        var: result is not changed
+
+    - name: Disable zone forwarding
+      ansible.posix.firewalld:
+        zone: custom
+        forward: false
+        permanent: true
+        state: enabled
+
+    - name: Assert zone forwarding is disabled
+      ansible.builtin.debug:
+        var: result is changed
+
+    - name: Disable zone forwarding (verify not changed)
+      ansible.posix.firewalld:
+        zone: custom
+        forward: false
+        permanent: true
+        state: enabled
+
+    - name: Assert zone forwarding is disabled (verify not changed)
+      ansible.builtin.debug:
+        var: result is not changed
+
 - name: Firewalld remove zone custom
   ansible.posix.firewalld:
     zone: custom


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Adds firewalld functionality to do the equivalent of `firewall-cmd --add-forwarding --zone={zone}`.
Functionality is exactly analogous to the `firewall-cmd --add-masquerade --zone={zone}` already present.

Fixes #529

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
firewalld

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Usage:
<!--- Paste verbatim command output below, e.g. before and after your change -->
```
- ansible.posix.firewalld:
    forward: true
    state: enabled
    permanent: true
    zone: internal
```
