### PR TITLE
[CI] Bump Azure test container to 6.0.0

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -37,7 +37,7 @@ variables:
 resources:
   containers:
     - container: default
-      image: quay.io/ansible/azure-pipelines-test-container:main
+      image: quay.io/ansible/azure-pipelines-test-container:6.0.0
 
 pool: Standard
 


### PR DESCRIPTION
##### SUMMARY

Replace AZP container image version with 6.0.0:

- Fixes https://github.com/ansible-collections/ansible.posix/issues/549

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
See https://github.com/ansible-collections/news-for-maintainers/issues/71
