### PR TITLE
Drop ansible-core 2.14 and set 2.15 minimum version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ For more information about communication, see the [Ansible communication guide](
 <!--start requires_ansible-->
 ## Ansible version compatibility
 
-This collection has been tested against following Ansible versions: **>=2.14**.
+This collection has been tested against following Ansible versions: **>=2.15**.
 <!--end requires_ansible-->
 
 ## Included content
@@ -74,10 +74,10 @@ None
 
 <!-- List the versions of Ansible the collection has been tested with. Must match what is in galaxy.yml. -->
 
-- ansible-core 2.17 (devel)
+- ansible-core 2.18 (devel)
+- ansible-core 2.17 (stable)
 - ansible-core 2.16 (stable)
 - ansible-core 2.15 (stable)
-- ansible-core 2.14 (stable)
 
 ## Roadmap
 

--- a/changelogs/fragments/562_update_core_version.yml
+++ b/changelogs/fragments/562_update_core_version.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - "Dropping support for ansible-core 2.14, ansible-core 2.15 will be minimum required version for this release"

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"


### PR DESCRIPTION
##### SUMMARY

Drop ansible-core 2.14 and set 2.15 minimum version.


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
```paste below
N/A
```
