### PR TITLE
(feat) add no_log option for 'opts' parameter

### DIFF
--- a/changelogs/fragments/563_add_no_log_option.yml
+++ b/changelogs/fragments/563_add_no_log_option.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - mount - add no_log option for opts parameter (https://github.com/ansible-collections/ansible.posix/pull/563).

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -43,6 +43,12 @@ options:
     description:
       - Mount options (see fstab(5), or vfstab(4) on Solaris).
     type: str
+  opts_no_log:
+    description:
+      - Do not log opts.
+    type: bool
+    default: false
+    version_added: 1.6.0
   dump:
     description:
       - Dump (see fstab(5)).
@@ -209,6 +215,7 @@ EXAMPLES = r'''
     src: //192.168.1.200/share
     path: /mnt/smb_share
     opts: "rw,vers=3,file_mode=0600,dir_mode=0700,dom={{ ad_domain }},username={{ ad_username }},password={{ ad_password }}"
+    opts_no_log: true
     fstype: cifs
     state: ephemeral
 '''
@@ -768,6 +775,7 @@ def main():
             fstype=dict(type='str'),
             path=dict(type='path', required=True, aliases=['name']),
             opts=dict(type='str'),
+            opts_no_log=dict(type='bool', default=False),
             passno=dict(type='str', no_log=False, default='0'),
             src=dict(type='path'),
             backup=dict(type='bool', default=False),
@@ -780,6 +788,9 @@ def main():
             ['state', 'ephemeral', ['src', 'fstype']]
         ),
     )
+
+    if module.params['opts_no_log']:
+        module.no_log_values.add(module.params['opts'])
 
     # solaris args:
     #   name, src, fstype, opts, boot, passno, state, fstab=/etc/vfstab

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -739,3 +739,53 @@
         - /tmp/myfs_A.img
         - /tmp/myfs_B.img
         - /tmp/myfs
+
+- name: Block to test opts_no_log option
+  when: ansible_system == 'Linux'
+  block:
+    - name: Create an empty file
+      community.general.filesize:
+        path: /tmp/myfs.img
+        size: 1M
+    - name: Format FS
+      community.general.filesystem:
+        fstype: ext4
+        dev: /tmp/myfs.img
+    - name: Mount the FS with opts_no_log option true
+      ansible.posix.mount:
+        path: /tmp/myfs
+        src: /tmp/myfs.img
+        fstype: ext4
+        state: mounted
+        opts: rw
+        opts_no_log: true
+      register: mount_info
+    - name: Assert opts_no_log option true
+      ansible.builtin.assert:
+        that:
+          - mount_info.opts == 'VALUE_SPECIFIED_IN_NO_LOG_PARAMETER'
+    - name: Remount the FS with opts_no_log option false
+      ansible.posix.mount:
+        path: /tmp/myfs
+        src: /tmp/myfs.img
+        fstype: ext4
+        state: remounted
+        opts: rw,user
+        opts_no_log: false
+      register: mount_info
+    - name: Assert opts_no_log option false
+      ansible.builtin.assert:
+        that:
+          - mount_info.opts == 'rw,user'
+  always:
+    - name: Unmount FS
+      ansible.posix.mount:
+        path: /tmp/myfs
+        state: absent
+    - name: Remove the test FS
+      ansible.builtin.file:
+        path: '{{ item }}'
+        state: absent
+      loop:
+        - /tmp/myfs.img
+        - /tmp/myfs


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Allows you to set no_log on just the opts parameter.
This is useful for CIFS/SMB mounts that would otherwise leak secrets.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Adds feature from issue: . #497 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mount

