### PR TITLE
Remove wrong version_added section from mount module

### DIFF
--- a/changelogs/fragments/567_remove_version_added.yml
+++ b/changelogs/fragments/567_remove_version_added.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - mount - remove wrong version_added section from ``opts_no_log``.

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -48,7 +48,6 @@ options:
       - Do not log opts.
     type: bool
     default: false
-    version_added: 1.6.0
   dump:
     description:
       - Dump (see fstab(5)).


### PR DESCRIPTION
##### SUMMARY
Remove the wrong version_added section from the mount module. It's not the collection version; it should be the ansible-core version.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME

ansible.posix.mount

##### ADDITIONAL INFORMATION
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
None
```
