### PR TITLE
authorized_key: Allow local path to a key

### DIFF
--- a/changelogs/fragments/568_update_authorized_key.yml
+++ b/changelogs/fragments/568_update_authorized_key.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - authorized_keys - allow using absolute path to a file as a SSH key(s) source (https://github.com/ansible-collections/ansible.posix/pull/568)

--- a/tests/integration/targets/authorized_key/defaults/main.yml
+++ b/tests/integration/targets/authorized_key/defaults/main.yml
@@ -35,3 +35,5 @@ multiple_keys_comments: |
   ssh-rsa DATA_BASIC 1@testing
   # I like adding comments yo-dude-this-is-not-a-key INVALID_DATA 2@testing
   ecdsa-sha2-nistp521 ECDSA_DATA 4@testing
+
+key_path: /tmp/id_rsa.pub

--- a/tests/integration/targets/authorized_key/tasks/check_path.yml
+++ b/tests/integration/targets/authorized_key/tasks/check_path.yml
@@ -1,0 +1,32 @@
+---
+- name: Create key file for test
+  ansible.builtin.copy:
+    dest: "{{ key_path }}"
+    content: "{{ rsa_key_basic }}"
+    mode: "0600"
+
+- name: Add key using path
+  ansible.posix.authorized_key:
+    user: root
+    key: file://{{ key_path }}
+    state: present
+    path: "{{ output_dir | expanduser }}/authorized_keys"
+  register: result
+
+- name: Assert that the key was added
+  ansible.builtin.assert:
+    that:
+      - result.changed == true
+
+- name: Add key using path again
+  ansible.posix.authorized_key:
+    user: root
+    key: file://{{ key_path }}
+    state: present
+    path: "{{ output_dir | expanduser }}/authorized_keys"
+  register: result
+
+- name: Assert that no changes were applied
+  ansible.builtin.assert:
+    that:
+      - result.changed == false

--- a/tests/integration/targets/authorized_key/tasks/main.yml
+++ b/tests/integration/targets/authorized_key/tasks/main.yml
@@ -31,3 +31,6 @@
 
 - name: Test for the management of comments with key
   ansible.builtin.import_tasks: comments.yml
+
+- name: Test for specifying key as a path
+  ansible.builtin.import_tasks: check_path.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add option to specify an absolute path to file with SSH key(s) for `authorized_key`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- `authorized_key`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Before this change you would need to get key using `ansible.builtin.slurp` or something like `ansible.builtin.command: cat <file>` with `register`
I tried to keep it as simple as possible

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# Now this is possible
- name: Set authorized keys taken from path
  ansible.posix.authorized_key:
    user: charlie
    state: present
    key: /home/charlie/.ssh/id_rsa.pub
```
