### PR TITLE
mount.py no rmdir when state=='absent'

### DIFF
--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -899,11 +899,6 @@ def main():
                     module.fail_json(
                         msg="Error unmounting %s: %s" % (name, msg))
 
-            if os.path.exists(name):
-                try:
-                    os.rmdir(name)
-                except (OSError, IOError) as e:
-                    module.fail_json(msg="Error rmdir %s: %s" % (name, to_native(e)))
     elif state == 'unmounted':
         if ismount(name) or is_bind_mounted(module, linux_mounts, name):
             if not module.check_mode:


### PR DESCRIPTION
##### SUMMARY
remove rmdir done after umounting when the requested state is 'absent'

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mount.py

##### ADDITIONAL INFORMATION
In function main(), remove rmdir in case : if state == 'absent'. 

Unmounting a file system should not lead to delete anything that is revealed after unmounting.  
Also, it leads to an error if a non empty directory is present under the ex-mountpoint after umount : [Errno 39] Directory not empty . So umount is successfull but the ansible run is failed. Of course, it is solved on second run.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# prepare for test
mkdir /var/my
mkdir /var/my/subdir
echo "some content" > /var/my/subdir/data

tree /var/my/
/var/my/
└── subdir
    └── data

# playbook used to mount
cat mount_mydata.yml
---
- name: mount my data
  hosts: localhost
  gather_facts: no
  become: yes
  tasks:
  - name: mount my data
    ansible.posix.mount:
      path: /var/my
      fstype: xfs
      state: mounted
      src: /dev/testVG/testLV
      # change with your own device

ansible-playbook mount_mydata.yml

PLAY [mount my data] **************************************************************************************************

TASK [mount my data] **************************************************************************************************
changed: [localhost]

PLAY RECAP ************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0

tree /var/my/
# gives something different
# may give no data or data depending on device content

# playbook to umount
cat unmount_mydata.yml
---
- name: unmount my data
  hosts: localhost
  gather_facts: no
  become: yes
  tasks:
  - name: unmount my data
    ansible.posix.mount:
      path: /var/my
      state: absent
      src: /dev/testVG/testLV
      # change with your own device
      backup: yes

# before code update, first run KO
ansible-playbook unmount_mydata.yml

PLAY [unmount my date] ************************************************************************************************

TASK [unmount my data] ************************************************************************************************
fatal: [localhost]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/libexec/platform-python"}, "changed": false, "msg": "Error rmdir /var/my: [Errno 39] Directory not empty: '/var/my'"}

PLAY RECAP ************************************************************************************************************
localhost                  : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0

# and need a second run to be OK
ansible-playbook unmount_mydata.yml

PLAY [unmount my date] ************************************************************************************************

TASK [unmount my data] ************************************************************************************************
ok: [localhost]

PLAY RECAP ************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0


# after code update one run is enough
ansible-playbook unmount_mydata.yml

PLAY [unmount my date] ************************************************************************************************

TASK [unmount my data] ************************************************************************************************
changed: [localhost]

PLAY RECAP ************************************************************************************************************
localhost                  : ok=1    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0

# back to original content
tree /var/my/
/var/my/
└── subdir
    └── data

```
