### PR TITLE
[CI] bump ansible-core version to 2.19 for devel branch

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -57,6 +57,21 @@ stages:
               test: units
             - name: Lint
               test: lint
+  - stage: Sanity_2_18
+    displayName: Ansible 2.18 sanity
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: "{0}"
+          testFormat: 2.18/{0}
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
+            - name: Lint
+              test: lint
   - stage: Sanity_2_17
     displayName: Ansible 2.17 sanity
     dependsOn: []
@@ -106,6 +121,20 @@ stages:
       - template: templates/matrix.yml
         parameters:
           testFormat: devel/linux/{0}/1
+          targets:
+            - name: Fedora 40
+              test: fedora40
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+            - name: Ubuntu 24.04
+              test: ubuntu2404
+  - stage: Docker_2_18
+    displayName: Docker devel
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.18/linux/{0}/1
           targets:
             - name: Fedora 40
               test: fedora40
@@ -176,6 +205,18 @@ stages:
               test: rhel/9.4
             - name: FreeBSD 13.3
               test: freebsd/13.3
+  - stage: Remote_2_18
+    displayName: Remote devel
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.18/{0}/1
+          targets:
+            - name: RHEL 9.4
+              test: rhel/9.4
+            - name: FreeBSD 13.3
+              test: freebsd/13.3
   - stage: Remote_2_17
     displayName: Remote 2.17
     dependsOn: []
@@ -234,8 +275,11 @@ stages:
       - Sanity_2_17
       - Remote_2_17
       - Docker_2_17
+      - Sanity_2_18
+      - Remote_2_18
+      - Docker_2_18
       - Sanity_devel
-      - Remote_devel
-      - Docker_devel
+      # - Remote_devel # Wait for test environment release
+      # - Docker_devel # Wait for test environment release
     jobs:
       - template: templates/coverage.yml

--- a/README.md
+++ b/README.md
@@ -74,10 +74,13 @@ None
 
 <!-- List the versions of Ansible the collection has been tested with. Must match what is in galaxy.yml. -->
 
-- ansible-core 2.18 (devel)
+- ansible-core 2.19 (devel)
+- ansible-core 2.18 (stable) *
 - ansible-core 2.17 (stable)
 - ansible-core 2.16 (stable)
 - ansible-core 2.15 (stable)
+
+*Note: For ansible-core 2.18, CI only covers sanity tests and no integration tests will be run until the test environment is released.*
 
 ## Roadmap
 

--- a/changelogs/fragments/571_ci_bump_core_version.yml
+++ b/changelogs/fragments/571_ci_bump_core_version.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Bump ansible-core version to 2.19 of devel branch and add 2.18 to CI.

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,0 +1,1 @@
+tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY

* bump devel test to ansible-core 2.19
* add ansible-core 2.18 to the stable list (CI only covers sanity tests at the moment)


##### ISSUE TYPE

- CI Pull Request

##### COMPONENT NAME
ansible.posix

##### ADDITIONAL INFORMATION
```paste below
None
```
