### PR TITLE
[DNM] [stable-1] Drop ansible-core 2.14 and set 2.15 minimum version on stable-1

### DIFF
--- a/changelogs/fragments/579_drop_ansible214.yml
+++ b/changelogs/fragments/579_drop_ansible214.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - backport - Drop ansible-core 2.14 and set 2.15 minimum version (https://github.com/ansible-collections/ansible.posix/issues/578).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"
 plugin_routing:
   callback:
     skippy:


### PR DESCRIPTION
##### SUMMARY

Drop ansible-core 2.14 and set 2.15 minimum version on stable-1

* Fixes #578 
* Backports #562 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
* ansible.posix (stable-1)

##### ADDITIONAL INFORMATION
None