### PR TITLE
[backport][stable-1] Drop ansible-core 2.14 and set 2.15 minimum version

### DIFF
--- a/changelogs/fragments/580_drop_ansible214.yml
+++ b/changelogs/fragments/580_drop_ansible214.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - backport - Drop ansible-core 2.14 and set 2.15 minimum version (https://github.com/ansible-collections/ansible.posix/issues/578).
+trivial:
+  - selinux - conditions for selinux integration tests have been modified to be more accurate.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: ">=2.14.0"
+requires_ansible: ">=2.15.0"
 plugin_routing:
   callback:
     skippy:

--- a/tests/integration/targets/selinux/tasks/selinux.yml
+++ b/tests/integration/targets/selinux/tasks/selinux.yml
@@ -128,8 +128,8 @@
   ansible.builtin.assert:
     that:
       - selinux_config_original | length == selinux_config_after | length
-      - selinux_config_after[selinux_config_after.index('SELINUX=disabled')]  is search("^SELINUX=\w+$")
-      - selinux_config_after[selinux_config_after.index('SELINUXTYPE=targeted')]  is search("^SELINUXTYPE=\w+$")
+      - (selinux_config_after | select("search", "^SELINUX=disabled\s*$") | list | length) > 0
+      - (selinux_config_after | select("search", "^SELINUXTYPE=targeted\s*$") | list | length) > 0
 
 - name: TEST 1 | Disable SELinux again, with kernel arguments update
   ansible.posix.selinux:


### PR DESCRIPTION
##### SUMMARY
1. Drop ansible-core 2.14 and set 2.15 minimum version.
2. Modify conditions for selinux integration tests to avoid RHEL7.9 integration test failure.

- backports #562
- fixes #578

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ansible.posix(stable-1)

##### ADDITIONAL INFORMATION
None
