### PR TITLE
Release 1.6.2 commit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,22 @@ ansible.posix Release Notes
 
 .. contents:: Topics
 
+v1.6.2
+======
+
+Release Summary
+---------------
+
+This is the bugfix release of the stable version ``ansible.posix`` collection.
+This changelog contains all changes to the modules and plugins
+in this collection that have been added after the release of
+``ansible.posix`` 1.6.1.
+
+Bugfixes
+--------
+
+- backport - Drop ansible-core 2.14 and set 2.15 minimum version (https://github.com/ansible-collections/ansible.posix/issues/578).
+
 v1.6.1
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -429,3 +429,19 @@ releases:
     - 571_ci_bump_core_version.yml
     - 572_revert_removal_of_skippy.yml
     release_date: '2024-10-11'
+  1.6.2:
+    changes:
+      bugfixes:
+      - backport - Drop ansible-core 2.14 and set 2.15 minimum version (https://github.com/ansible-collections/ansible.posix/issues/578).
+      release_summary: 'This is the bugfix release of the stable version ``ansible.posix``
+        collection.
+
+        This changelog contains all changes to the modules and plugins
+
+        in this collection that have been added after the release of
+
+        ``ansible.posix`` 1.6.1.'
+    fragments:
+    - 1.6.2.yml
+    - 580_drop_ansible214.yml
+    release_date: '2024-10-22'

--- a/changelogs/fragments/580_drop_ansible214.yml
+++ b/changelogs/fragments/580_drop_ansible214.yml
@@ -1,5 +1,0 @@
----
-bugfixes:
-  - backport - Drop ansible-core 2.14 and set 2.15 minimum version (https://github.com/ansible-collections/ansible.posix/issues/578).
-trivial:
-  - selinux - conditions for selinux integration tests have been modified to be more accurate.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: ansible
 name: posix
-version: 1.6.1
+version: 1.6.2
 readme: README.md
 authors:
   - Ansible (github.com/ansible)


### PR DESCRIPTION
##### SUMMARY
Release 1.6.2 commit. The purpose of this release is to fix the version information that was reverted in 1.6.1.
It will replace the minimum version of Ansible Core 2.14 with 2.15.

* #149 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
* ansible.posix(stable-1)

##### ADDITIONAL INFORMATION
```paste below
None
```
