### PR TITLE
Replace FreeBSD 13.3 with 13.4 and add FreeBSD 14.1 for devel

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -203,8 +203,10 @@ stages:
           targets:
             - name: RHEL 9.4
               test: rhel/9.4
-            - name: FreeBSD 13.3
-              test: freebsd/13.3
+            - name: FreeBSD 14.1
+              test: freebsd/14.1
+            - name: FreeBSD 13.4
+              test: freebsd/13.4
   - stage: Remote_2_18
     displayName: Remote devel
     dependsOn: []

--- a/changelogs/fragments/593_replace_freebsd_version.yml
+++ b/changelogs/fragments/593_replace_freebsd_version.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Replaced FreeBSD version 13.3 with 13.4 and 14.1 in CI for devel branch.


### PR DESCRIPTION
##### SUMMARY

Replace FreeBSD 13.3 with 13.4 and add FreeBSD 14.1 for integration test environments for ansible-core devel branch.

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME

- ansible.posix

##### ADDITIONAL INFORMATION
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
None
```
