### PR TITLE
sysctl: Update custom sysctl file example

### DIFF
--- a/plugins/modules/sysctl.py
+++ b/plugins/modules/sysctl.py
@@ -80,6 +80,13 @@ EXAMPLES = r'''
     sysctl_file: /tmp/test_sysctl.conf
     reload: false
 
+# Enable resource limits management in FreeBSD
+- ansible.posix.sysctl:
+    name: kern.racct.enable
+    value: '1'
+    sysctl_file: /boot/loader.conf
+    reload: false
+
 # Set ip forwarding on in /proc and verify token value with the sysctl command
 - ansible.posix.sysctl:
     name: net.ipv4.ip_forward


### PR DESCRIPTION
##### SUMMARY
FreeBSD's [/boot/loader.conf](https://man.freebsd.org/cgi/man.cgi?loader.conf) may contain both `rc` and `sysctl`-like entries.

When I tried to edit this file with Ansible's `sysrc` module, I found out that it [does not support](https://docs.ansible.com/ansible/latest/collections/community/general/sysrc_module.html#notes) dot-separated keys. Searching the Internet wasn't helpful, but eventually, I realised I could modify the file with the `sysctl` module.

I think the existing example with `/tmp/test_sysctl.conf` is a bit contrived, so replacing it with `/boot/loader.conf` will make a real-world use case, and make it searchable on the Internet for others who run into the same issue as I did. It will also make it more consistent with the sysrc [examples](https://docs.ansible.com/ansible/latest/collections/community/general/sysrc_module.html#examples) that reference that file.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
`sysctl`

##### ADDITIONAL INFORMATION
n/a