### PR TITLE
Fix sanitize mount src before comparing to mount point for macOS

### DIFF
--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -222,6 +222,7 @@ EXAMPLES = r'''
 import errno
 import os
 import platform
+import re
 
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.ansible.posix.plugins.module_utils.mount import ismount
@@ -731,7 +732,8 @@ def _is_same_mount_src(module, src, mountpoint, linux_mounts):
             not ismount(mountpoint) and
             not is_bind_mounted(module, linux_mounts, mountpoint)):
         return False
-
+    # sanitize src
+    src = re.sub(r'(//[^:]+):([^@]+)@', r'\1@', src)
     # Treat Linux bind mounts
     if platform.system() == 'Linux' and linux_mounts is not None:
         # For Linux bind mounts only: the mount command does not return


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The mount command `mount_smbfs` on macOS doesn't have a separated parameter for password, hence the `src` parameter attaches password like below:

```
- name: synology storage mount
      ansible.posix.mount:
        src: //{{SYNOLOGY_USERNAME}}:{{SYNOLOGY_PASSWORD}}@10.10.10.251/storage
        path: /Users/kidy/Synology/storage
        fstype: smbfs
        state: ephemeral
``` 

It occurs below error when it mounted on second run: 

``Ephemeral mount point is already mounted with a different source than the specified one. Failing in order to prevent an unwanted unmount or override operation. Try replacing this command with a \"state: unmounted\" followed by a \"state: ephemeral\", or use a different destination path.`` 

The reason is it trying to compare 
`src: //{{SYNOLOGY_USERNAME}}:{{SYNOLOGY_PASSWORD}}@10.10.10.251/storage`
 to the mount point: 
`//{{SYNOLOGY_USERNAME}}@10.10.10.251/storage`


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mount
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```python
# sanitize src
src = re.sub(r'(//[^:]+):([^@]+)@', r'\1@', src)
```
