### PR TITLE
acl: correctly assert needed changes when recursive is true

### DIFF
--- a/changelogs/fragments/638_fix_recursive_acl.yml
+++ b/changelogs/fragments/638_fix_recursive_acl.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - acl - correctly assert needed changes when pointing to a directory and recursive is set to true.

--- a/plugins/modules/acl.py
+++ b/plugins/modules/acl.py
@@ -243,12 +243,18 @@ def acl_changed(module, cmd, entry, use_nfsv4_acls=False):
     cmd.insert(1, '--test')
     lines = run_acl(module, cmd)
     counter = 0
+    lines_checked = 0
+    lines_unchanged = 0
     for line in lines:
+        lines_checked += 1
         if line.endswith('*,*') and not use_nfsv4_acls:
-            return False
+            lines_unchanged += 1
         # if use_nfsv4_acls and entry is listed
         if use_nfsv4_acls and entry == line:
             counter += 1
+
+    if lines_unchanged == lines_checked:
+        return False
 
     # The current 'nfs4_setfacl --test' lists a new entry,
     #  which will be added at the top of list, followed by the existing entries.

--- a/plugins/modules/acl.py
+++ b/plugins/modules/acl.py
@@ -243,23 +243,17 @@ def acl_changed(module, cmd, entry, use_nfsv4_acls=False):
     cmd.insert(1, '--test')
     lines = run_acl(module, cmd)
     counter = 0
-    lines_checked = 0
-    lines_unchanged = 0
     for line in lines:
-        lines_checked += 1
-        if line.endswith('*,*') and not use_nfsv4_acls:
-            lines_unchanged += 1
+        if not use_nfsv4_acls and not line.endswith('*,*'):
+            return True
         # if use_nfsv4_acls and entry is listed
         if use_nfsv4_acls and entry == line:
             counter += 1
 
-    if lines_unchanged == lines_checked:
-        return False
-
     # The current 'nfs4_setfacl --test' lists a new entry,
-    #  which will be added at the top of list, followed by the existing entries.
-    # So if the entry has already been registered, the entry should be find twice.
-    if counter == 2:
+    # which will be added at the top of the list, followed by the existing entries.
+    # So if the entry has already been registered, the entry should be found twice.
+    if not use_nfsv4_acls or counter == 2:
         return False
     return True
 

--- a/tests/integration/targets/acl/tasks/acl.yml
+++ b/tests/integration/targets/acl/tasks/acl.yml
@@ -1,20 +1,6 @@
 ---
 # (c) 2017, Martin Krizek <mkrizek@redhat.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: Create ansible user
   ansible.builtin.user:
@@ -43,15 +29,17 @@
 
 - name: Create ansible dir
   ansible.builtin.file:
-    path: "{{ test_dir }}"
+    path: "{{ item.path }}"
     state: directory
-    mode: "0755"
+    mode: "{{ item.mode }}"
+  loop:
+    - { path: "{{ test_dir }}", mode: "0755" }
+    - { path: "{{ test_recursive_dir }}", mode: "0755" }
 
 - name: Install acl package
   ansible.builtin.package:
     name: acl
     state: present
-
 ##############################################################################
 - name: Grant ansible user read access to a file
   ansible.posix.acl:
@@ -249,3 +237,38 @@
       - "'default:mask::rwx' in getfacl_output.stdout_lines"
       - "'default:other::r-x' in getfacl_output.stdout_lines"
       - "'default:group:{{ test_group }}:rw-' not in getfacl_output.stdout_lines"
+
+##############################################################################
+
+- name: create file
+  ansible.builtin.copy:
+    dest: "{{ test_recursive_dir }}/txt.txt"
+    mode: '0440'
+    content: "hw"
+
+- name: Change ACLs recursively
+  ansible.posix.acl:
+    path: "{{ test_recursive_dir }}"
+    entity: "{{ test_user }}"
+    etype: user
+    permissions: rX
+    state: present
+    recursive: true
+  register: output_acl_change
+
+- name: Remove ACLs recursively again
+  ansible.posix.acl:
+    path: "{{ test_recursive_dir }}"
+    entity: "{{ test_user }}"
+    etype: user
+    permissions: r
+    state: present
+    recursive: true
+  register: output_acl_remove
+
+- assert:
+    that:
+      - output_acl_change is changed
+      - output_acl_change is not failed
+      - output_acl_remove is changed
+      - output_acl_remove is not failed

--- a/tests/integration/targets/acl/tasks/main.yml
+++ b/tests/integration/targets/acl/tasks/main.yml
@@ -1,20 +1,6 @@
 ---
 # (c) 2017, Martin Krizek <mkrizek@redhat.com>
-
-# This file is part of Ansible
-#
-# Ansible is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# Ansible is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 - name: Test ACL
   vars:
@@ -22,6 +8,7 @@
     test_group: ansible_group
     test_file: "{{ output_dir }}/ansible file"
     test_dir: "{{ output_dir }}/ansible_dir/with some space"
+    test_recursive_dir: "{{ output_dir }}/recursive_dir"
   block:
     - name: Include tests task file
       ansible.builtin.include_tasks: acl.yml


### PR DESCRIPTION
##### SUMMARY

Right now, when setting recursive ACLs on a directory, all files in the directory are tested to check if a change is needed. If a single file has expected ACLs already set, then the test returns `False` and no changes are applied.

Fixes #592

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME

acl

##### ADDITIONAL INFORMATION

I'm very much a beginner in Python, so any criticism is welcome.