### PR TITLE
Remove EOL FreeBSD 13.2 from CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -237,8 +237,6 @@ stages:
               test: rhel/8.8
             - name: RHEL 9.2
               test: rhel/9.2
-            - name: FreeBSD 13.2
-              test: freebsd/13.2
 
   - stage: Remote_2_15
     displayName: Remote 2.15
@@ -254,8 +252,6 @@ stages:
               test: rhel/8.7
             - name: RHEL 9.1
               test: rhel/9.1
-            - name: FreeBSD 13.2
-              test: freebsd/13.2
 
   ## Finally
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
CI seems to be failing for a month, reason is that freebsd 13.2 is no longer valid.

See https://github.com/ansible-collections/community.general/pull/8607
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
CI
