### PR TITLE
profile_* callbacks: avoid deprecated/deleted functions

### DIFF
--- a/changelogs/fragments/650-profile_tasks_roles.yml
+++ b/changelogs/fragments/650-profile_tasks_roles.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "profile_tasks and profile_roles callback plugins - avoid deleted/deprecated callback functions, instead use modern interface that was introduced a longer time ago (https://github.com/ansible-collections/ansible.posix/issues/650)."

--- a/plugins/callback/profile_roles.py
+++ b/plugins/callback/profile_roles.py
@@ -124,10 +124,7 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_handler_task_start(self, task):
         self._record_task(task)
 
-    def playbook_on_setup(self):
-        self._display_tasktime()
-
-    def playbook_on_stats(self, stats):
+    def v2_playbook_on_stats(self, stats):
         # Align summary report header with other callback plugin summary
         self._display.banner("ROLES RECAP")
 

--- a/plugins/callback/profile_tasks.py
+++ b/plugins/callback/profile_tasks.py
@@ -209,10 +209,7 @@ class CallbackModule(CallbackBase):
     def v2_playbook_on_handler_task_start(self, task):
         self._record_task(task)
 
-    def playbook_on_setup(self):
-        self._display_tasktime()
-
-    def playbook_on_stats(self, stats):
+    def v2_playbook_on_stats(self, stats):
         # Align summary report header with other callback plugin summary
         self._display.banner("TASKS RECAP")
 


### PR DESCRIPTION
##### SUMMARY
The profile_roles and profile_tasks callbacks define methods `playbook_on_setup` and `playbook_on_stats` which have been deleted/deprecated:

- `playbook_on_stats` has been deprecated, `v2_playbook_on_stats` should be used instead (that one has already been there for many years: https://github.com/ansible/ansible/commit/ba0e5323d6feca04b721ae164e69b68bc1e97b92 was added in 2015).
- `playbook_on_setup` has been deleted (https://github.com/ansible/ansible/commit/eec57ec3965a6887c737e8b629e853ccf295d3ec), and its v2 variant was already deleted in 2017: https://github.com/ansible/ansible/commit/59d5481abb91c4d3b0bb96b8e8e592bb1dc3d234

Ref: #635

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
profile_roles
profile_tasks
