### PR TITLE
[CI] bump ansible-core version to 2.20 for devel branch

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -57,8 +57,23 @@ stages:
               test: units
             - name: Lint
               test: lint
+  - stage: Sanity_2_19
+    displayName: Ansible 2.19 sanitay & Units & Lint
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: "{0}"
+          testFormat: 2.19/{0OI}
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
+            - name: Lint
+              test: lint
   - stage: Sanity_2_18
-    displayName: Ansible 2.18 sanity
+    displayName: Ansible 2.18 sanity & Units & Lint
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
@@ -73,10 +88,11 @@ stages:
             - name: Lint
               test: lint
   - stage: Sanity_2_17
-    displayName: Ansible 2.17 sanity
+    displayName: Ansible 2.17 sanity & Units & Lint
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
+        I
         parameters:
           nameFormat: "{0}"
           testFormat: 2.17/{0}
@@ -88,7 +104,7 @@ stages:
             - name: Lint
               test: lint
   - stage: Sanity_2_16
-    displayName: Ansible 2.16 sanity
+    displayName: Ansible 2.16 sanity & Units & Lint
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
@@ -101,7 +117,7 @@ stages:
             - name: Units
               test: units
   - stage: Sanity_2_15
-    displayName: Ansible 2.15 sanity
+    displayName: Ansible 2.15 sanity & Units & Lint
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
@@ -116,6 +132,20 @@ stages:
   ## Docker
   - stage: Docker_devel
     displayName: Docker devel
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: devel/linux/{0}/1
+          targets:
+            - name: Fedora 41
+              test: fedora41
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+            - name: Ubuntu 24.04
+              test: ubuntu2404
+  - stage: Docker_2_19
+    displayName: Docker 2.19
     dependsOn: []
     jobs:
       - template: templates/matrix.yml
@@ -203,6 +233,22 @@ stages:
               test: freebsd/14.2
             - name: FreeBSD 13.5
               test: freebsd/13.5
+  - stage: Remote_2_19
+    displayName: Remote 2.19
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: devel/{0}/1
+          targets:
+            - name: RHEL 10.0
+              test: rhel/10.0
+            - name: RHEL 9.5
+              test: rhel/9.5
+            - name: FreeBSD 14.2
+              test: freebsd/14.2
+            - name: FreeBSD 13.5
+              test: freebsd/13.5
   - stage: Remote_2_18
     displayName: Remote 2.18
     dependsOn: []
@@ -272,6 +318,9 @@ stages:
       - Sanity_2_18
       - Remote_2_18
       - Docker_2_18
+      - Sanity_2_19
+      - Remote_2_19
+      - Docker_2_19
       - Sanity_devel
       - Remote_devel
       - Docker_devel

--- a/changelogs/fragments/654_ci_bump_core_version.yml
+++ b/changelogs/fragments/654_ci_bump_core_version.yml
@@ -1,0 +1,3 @@
+~--
+trivial:
+  - Bump ansible-core version to 2.20 of devel branch and add 2.19 to CI

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,0 +1,1 @@
+tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY

Bump ansible-core version to 2.20 for devel branch.

- Bump devel test to ansible-core 2.19
- Add ansible-core 2.18 to the stable list

##### ISSUE TYPE
- CI Pull Request

##### COMPONENT NAME

- ansible.posix

##### ADDITIONAL INFORMATION

```
None
```
