### PR TITLE
Add datetime_format to profile_roles providing a different date/time format

### DIFF
--- a/changelogs/fragments/657_profile_roles_datetime_format.yml
+++ b/changelogs/fragments/657_profile_roles_datetime_format.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - profile_roles - Add option to provide a different date/time format (https://github.com/ansible-collections/ansible.posix/issues/628).


### PR DESCRIPTION
##### SUMMARY

Add datetime_format to profile_roles, providing a different date/time format:

- Addresses #628
- References #626

You can specify `datetime_format` in `callback_profile` section in `ansible.cfg`, or you can specify `PROFILE_ROLES_FORMAT` as an environment variable.

```
[callback_profile_roles]
datetime_format = '%m-%dT%H:%M:%S.%f%z'
```

If these specifications are not specified, the datetime format will be output in the conventional format.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- ansible.posix.profile_roles

##### ADDITIONAL INFORMATION
```paste below
None
```
