### PR TITLE
Use module.warn() instead of returning warnings

### DIFF
--- a/changelogs/fragments/670-deprecations.yml
+++ b/changelogs/fragments/670-deprecations.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "firewalld_info - stop returning warnings as return values; this has been deprecated by ansible-core (https://github.com/ansible-collections/ansible.posix/pull/670)."
+  - "mount - stop returning warnings as return values; this has been deprecated by ansible-core (https://github.com/ansible-collections/ansible.posix/pull/670)."

--- a/plugins/modules/firewalld_info.py
+++ b/plugins/modules/firewalld_info.py
@@ -319,7 +319,6 @@ def main():
         active_zones=module.params['active_zones'],
         collected_zones=list(),
         undefined_zones=list(),
-        warnings=list(),
     )
 
     # Exit with failure message if requirements modules are not installed.

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -279,7 +279,7 @@ def _set_mount_save_old(module, args):
     old_lines = []
     exists = False
     changed = False
-    escaped_args = dict([(k, _escape_fstab(v)) for k, v in iteritems(args) if k != 'warnings'])
+    escaped_args = dict([(k, _escape_fstab(v)) for k, v in iteritems(args)])
     new_line = '%(src)s %(name)s %(fstype)s %(opts)s %(dump)s %(passno)s\n'
 
     if platform.system() == 'SunOS':
@@ -804,7 +804,6 @@ def main():
             passno='-',
             fstab=module.params['fstab'],
             boot='yes' if module.params['boot'] else 'no',
-            warnings=[]
         )
         if args['fstab'] is None:
             args['fstab'] = '/etc/vfstab'
@@ -816,7 +815,6 @@ def main():
             passno='0',
             fstab=module.params['fstab'],
             boot='yes',
-            warnings=[]
         )
         if args['fstab'] is None:
             args['fstab'] = '/etc/fstab'
@@ -834,8 +832,7 @@ def main():
         linux_mounts = get_linux_mounts(module)
 
         if linux_mounts is None:
-            args['warnings'].append('Cannot open file /proc/self/mountinfo.'
-                                    ' Bind mounts might be misinterpreted.')
+            module.warn('Cannot open file /proc/self/mountinfo. Bind mounts might be misinterpreted.')
 
     # Override defaults with user specified params
     for key in ('src', 'fstype', 'passno', 'opts', 'dump', 'fstab'):
@@ -847,7 +844,7 @@ def main():
         # specified in 'opts',  mount module will ignore 'boot'.
         opts = args['opts'].split(',')
         if module.params['boot'] and 'noauto' in opts:
-            args['warnings'].append("Ignore the 'boot' due to 'opts' contains 'noauto'.")
+            module.warn("Ignore the 'boot' due to 'opts' contains 'noauto'.")
         elif not module.params['boot']:
             args['boot'] = 'no'
             opts.append('noauto')


### PR DESCRIPTION
##### SUMMARY
Returning warnings as `warnings` has been deprecated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
firewalld_info
mount
