### PR TITLE
CI: actually use 2.19 instead of devel for 2.19 tests

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -149,7 +149,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/linux/{0}/1
+          testFormat: 2.19/linux/{0}/1
           targets:
             - name: Fedora 42
               test: fedora42
@@ -238,7 +238,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
-          testFormat: devel/{0}/1
+          testFormat: 2.19/{0}/1
           targets:
             - name: RHEL 10.0
               test: rhel/10.0


### PR DESCRIPTION
##### SUMMARY
The Docker and VM integration tests for 2.19 actually use devel and not 2.19.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI matrix
