### PR TITLE
Fix _AnsibleActionDone deprecation in patch plugin

### DIFF
--- a/changelogs/fragments/patch_removed.yml
+++ b/changelogs/fragments/patch_removed.yml
@@ -1,0 +1,3 @@
+---
+removed_features:
+    - patch - removed deprecated _AnsibleActionDone API (https://github.com/ansible-collections/ansible.posix/pull/687).

--- a/plugins/action/patch.py
+++ b/plugins/action/patch.py
@@ -20,7 +20,7 @@ __metaclass__ = type
 
 import os
 
-from ansible.errors import AnsibleError, AnsibleAction, _AnsibleActionDone, AnsibleActionFail
+from ansible.errors import AnsibleError, AnsibleAction, AnsibleActionFail
 from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.parsing.convert_bool import boolean
 from ansible.plugins.action import ActionBase
@@ -46,7 +46,8 @@ class ActionModule(ActionBase):
             elif remote_src:
                 # everything is remote, so we just execute the module
                 # without changing any of the module arguments
-                raise _AnsibleActionDone(result=self._execute_module(task_vars=task_vars))
+                result.update(self._execute_module(task_vars=task_vars))
+                return result
 
             try:
                 src = self._find_needle('files', src)


### PR DESCRIPTION
##### SUMMARY
Minimal fix for the deprecation warning in the patch plugin.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
patch 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
