### PR TITLE
Fix to_native deprecation warning in authorized_key module

### DIFF
--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -227,7 +227,7 @@ import re
 import shlex
 from operator import itemgetter
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.urls import fetch_url
 from ansible.module_utils.six.moves.urllib.parse import urlparse


### PR DESCRIPTION
##### SUMMARY

Fix the deprecation warning in authorized_key module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
authorized_key

##### ADDITIONAL INFORMATION

```text
[DEPRECATION WARNING]: Importing 'to_native' from 'ansible.module_utils._text' is deprecated. This feature will be removed from ansible-core version 2.24. Use ansible.module_utils.common.text.converters instead.
```
