### PR TITLE
[CI] Update AZP CI matrix and sanity tests

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -57,6 +57,21 @@ stages:
               test: units
             - name: Lint
               test: lint
+  - stage: Sanity_2_20
+    displayName: Ansible 2.20 Sanity & Units & Lint
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          nameFormat: "{0}"
+          testFormat: 2.20/{0}
+          targets:
+            - name: Sanity
+              test: sanity
+            - name: Units
+              test: units
+            - name: Lint
+              test: lint
   - stage: Sanity_2_19
     displayName: Ansible 2.19 Sanity & Units & Lint
     dependsOn: []
@@ -125,6 +140,20 @@ stages:
       - template: templates/matrix.yml
         parameters:
           testFormat: devel/linux/{0}/1
+          targets:
+            - name: Fedora 42
+              test: fedora42
+            - name: Ubuntu 22.04
+              test: ubuntu2204
+            - name: Ubuntu 24.04
+              test: ubuntu2404
+  - stage: Docker_2_20
+    displayName: Docker 2.20
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.20/linux/{0}/1
           targets:
             - name: Fedora 42
               test: fedora42
@@ -204,6 +233,22 @@ stages:
               test: freebsd/14.3
             - name: FreeBSD 13.5
               test: freebsd/13.5
+  - stage: Remote_2_20
+    displayName: Remote 2.20
+    dependsOn: []
+    jobs:
+      - template: templates/matrix.yml
+        parameters:
+          testFormat: 2.20/{0}/1
+          targets:
+            - name: RHEL 10.0
+              test: rhel/10.0
+            - name: RHEL 9.6
+              test: rhel/9.6
+            - name: FreeBSD 14.3
+              test: freebsd/14.3
+            - name: FreeBSD 13.5
+              test: freebsd/13.5
   - stage: Remote_2_19
     displayName: Remote 2.19
     dependsOn: []
@@ -228,6 +273,8 @@ stages:
         parameters:
           testFormat: 2.18/{0}/1
           targets:
+            - name: RHEL 10.0
+              test: rhel/10.0
             - name: RHEL 9.4
               test: rhel/9.4
             - name: FreeBSD 13.5
@@ -240,8 +287,9 @@ stages:
         parameters:
           testFormat: 2.17/{0}/1
           targets:
-            - name: RHEL 9.3
-              test: rhel/9.3
+            # 2.17 remote target doesn't have RHEL 9 image
+            - name: RHEL 10.0
+              test: rhel/10.0
             - name: FreeBSD 13.5
               test: freebsd/13.5
   - stage: Remote_2_16
@@ -252,10 +300,9 @@ stages:
         parameters:
           testFormat: 2.16/{0}/1
           targets:
-            - name: RHEL 8.8
-              test: rhel/8.8
-            - name: RHEL 9.2
-              test: rhel/9.2
+            # 2.16 remote target only has RHEL 9.6 image
+            - name: RHEL 9.6
+              test: rhel/9.6
 
   ## Finally
 
@@ -274,6 +321,9 @@ stages:
       - Sanity_2_19
       - Remote_2_19
       - Docker_2_19
+      - Sanity_2_20
+      - Remote_2_20
+      - Docker_2_20
       - Sanity_devel
       - Remote_devel
       - Docker_devel

--- a/changelogs/fragments/693_azp_update_20251205.yml
+++ b/changelogs/fragments/693_azp_update_20251205.yml
@@ -1,0 +1,5 @@
+---
+trivial:
+  - AZP - Update AZP matrix to follow ansible-test changes.
+  - Add ignore file for Ansible Core 2.21.
+  - Remove ignore lines for ansible-bad-import-from in 2.20 sanity tests.

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,10 +1,1 @@
 tests/utils/shippable/timing.py shebang
-plugins/action/synchronize.py pylint:ansible-bad-import-from
-plugins/callback/cgroup_perf_recap.py pylint:ansible-bad-import-from
-plugins/modules/mount.py pylint:ansible-bad-import-from
-plugins/modules/sysctl.py pylint:ansible-bad-import-from
-plugins/shell/csh.py pylint:ansible-bad-import-from
-plugins/shell/fish.py pylint:ansible-bad-import-from
-tests/unit/mock/procenv.py pylint:ansible-bad-import-from
-tests/unit/mock/yaml_helper.py pylint:ansible-bad-import-from
-tests/unit/modules/conftest.py pylint:ansible-bad-import-from

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,10 @@
+tests/utils/shippable/timing.py shebang
+plugins/action/synchronize.py pylint:ansible-bad-import-from
+plugins/callback/cgroup_perf_recap.py pylint:ansible-bad-import-from
+plugins/modules/mount.py pylint:ansible-bad-import-from
+plugins/modules/sysctl.py pylint:ansible-bad-import-from
+plugins/shell/csh.py pylint:ansible-bad-import-from
+plugins/shell/fish.py pylint:ansible-bad-import-from
+tests/unit/mock/procenv.py pylint:ansible-bad-import-from
+tests/unit/mock/yaml_helper.py pylint:ansible-bad-import-from
+tests/unit/modules/conftest.py pylint:ansible-bad-import-from


### PR DESCRIPTION
##### SUMMARY

* Update AZP CI matrix. Bump the remote target version for 2.16 and 2.17
* Add ignore file for Ansible Core 2.21 for the current devel version sanity test

##### ISSUE TYPE
- CI tests Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
None