### PR TITLE
Remove unmaintained pycrypto from unit test requirements

### DIFF
--- a/changelogs/fragments/652-remove-pycrypto.yml
+++ b/changelogs/fragments/652-remove-pycrypto.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Remove unmaintained and vulnerable ``pycrypto`` dependency from unit test requirements.

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,6 +1,5 @@
 boto3
 placebo
-pycrypto
 passlib
 pypsrp
 python-memcached


### PR DESCRIPTION
##### SUMMARY
Remove the unmaintained and vulnerable `pycrypto` dependency from unit test requirements.
The dependency is not used anywhere in the codebase and causes recurring CI security scan failures.

Fixes #652

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/unit/requirements.txt
