### PR TITLE
docs: added attributes metadata for check_mode support (fixes #643)

### DIFF
--- a/changelogs/fragments/643-sysctl-docs.yml
+++ b/changelogs/fragments/643-sysctl-docs.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - sysctl - added the attributes section to the module documentation to reflect check_mode support (https://github.com/ansible-collections/ansible.posix/issues/643).

--- a/plugins/modules/sysctl.py
+++ b/plugins/modules/sysctl.py
@@ -56,6 +56,17 @@ options:
             - Verify token value with the sysctl command and set with C(-w) if necessary.
         type: bool
         default: false
+attributes:
+  check_mode:
+    support: full
+    description: Can run in check_mode and return changed status prediction without modifying target.
+  diff_mode:
+    support: none
+    description: Does not support differences output.
+  platform:
+    platforms: posix
+    support: full
+    description: Supported on POSIX-compliant systems.
 author:
 - David CHANIAL (@davixx)
 '''


### PR DESCRIPTION
SUMMARY
This PR updates the sysctl module documentation to explicitly declare its support for check_mode.

While the module's Python logic already supported dry-runs, the missing attributes metadata meant this wasn't reflected in the official documentation or the ansible-doc output. This change adds the required attributes block (including check_mode, diff_mode, and platform) to satisfy the collection's documentation schema and improve user visibility into module capabilities.

Fixes #643
Signed-off-by: Jason Hall jason.kei.hall@gmail.com

ISSUE TYPE 
Docs Pull Request

COMPONENT NAME 
plugins/modules/sysctl.py 
changelogs/fragments/643-sysctl-docs.yml