### PR TITLE
acl: now fails gracefully when nfsv4 permissions are missing (fixes #…

### DIFF
--- a/changelogs/fragments/679-acl-nfsv4-typeerror.yml
+++ b/changelogs/fragments/679-acl-nfsv4-typeerror.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - acl - fix a `TypeError` crash when `use_nfsv4_acls=true` and `permissions` are omitted by adding a validation check that fails gracefully with a helpful message (https://github.com/ansible-collections/ansible.posix/issues/679).

--- a/plugins/modules/acl.py
+++ b/plugins/modules/acl.py
@@ -335,6 +335,9 @@ def main():
         if state == 'absent' and permissions and not use_nfsv4_acls:
             module.fail_json(msg="'permissions' MUST NOT be set when 'state=absent'.")
 
+        if use_nfsv4_acls and state in ['present', 'absent'] and permissions is None:
+            module.fail_json(msg="The 'permissions' parameter is required when 'use_nfsv4_acls' is true.")
+
         if state == 'absent' and not entity:
             module.fail_json(msg="'entity' MUST be set when 'state=absent'.")
 

--- a/tests/integration/targets/acl/tasks/acl.yml
+++ b/tests/integration/targets/acl/tasks/acl.yml
@@ -249,3 +249,21 @@
       - "'default:mask::rwx' in getfacl_output.stdout_lines"
       - "'default:other::r-x' in getfacl_output.stdout_lines"
       - "'default:group:{{ test_group }}:rw-' not in getfacl_output.stdout_lines"
+
+- name: Trigger acl module with NFSv4 and no permissions
+  ansible.posix.acl:
+    path: "{{ test_dir }}"
+    entity: "{{ test_user }}"
+    etype: user
+    state: absent
+    use_nfsv4_acls: true
+  register: crash_test
+  ignore_errors: true
+
+- name: Verify the module did not crash with a TypeError
+  ansible.builtin.assert:
+    that:
+      - crash_test is failed
+      - "'unsupported operand type' not in (crash_test.module_stderr | default(''))"
+      - "crash_test.msg is search('permissions.*required')"
+    msg: "The module crashed with a TypeError instead of failing with a helpful error message!"


### PR DESCRIPTION
SUMMARY 
This PR fixes a TypeError crash in the acl module when use_nfsv4_acls is set to true but permissions are omitted.

Previously, the module would attempt to concatenate None with the NFSv4 attribute string (tcy), resulting in a traceback. This change adds a validation check in the main function to ensure that permissions are provided when working with NFSv4 ACLs, ensuring the module fails gracefully via fail_json with a helpful error message.

Fixes #679
Signed-off-by: Jason Hall jason.kei.hall@gmail.com

ISSUE TYPE 
Bugfix Pull Request

COMPONENT NAME 
plugins/modules/acl.py 
tests/integration/targets/acl/tasks/main.yml 
changelogs/fragments/679-acl-nfsv4-typeerror.yml