### PR TITLE
fix #684: correctly handle multiple mixed key sources separated by ne…

### DIFF
--- a/changelogs/fragments/684-fix-mixed-authorized-key-sources.yml
+++ b/changelogs/fragments/684-fix-mixed-authorized-key-sources.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - authorized_key - fix a bug where providing multiple key sources (URLs or file paths) separated by newlines would fail or only process the first source. The module now correctly resolves each source in a newline-separated list before processing the keys (https://github.com/ansible-collections/ansible.posix/issues/684).

--- a/tests/integration/targets/authorized_key/tasks/multiple_keys.yml
+++ b/tests/integration/targets/authorized_key/tasks/multiple_keys.yml
@@ -95,3 +95,35 @@
       - result.changed == False
       - multiple_keys_comments.stdout == multiple_key_exclusive.strip()
       - result.key_options == None
+
+- name: Create local key source simulating a URL response
+  ansible.builtin.copy:
+    dest: "{{ output_dir | expanduser }}/simulated_url.txt"
+    content: |
+      ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDXJ1HrhQEXOexamplekey1fromurl test1@example.com
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGexamplekey2fromurl test2@example.com
+    mode: "0644"
+
+- name: Add mixed keys (file source + raw key)
+  ansible.posix.authorized_key:
+    user: root
+    key: |
+      file://{{ output_dir | expanduser }}/simulated_url.txt
+      ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqmqp9pP9pP9pP9pP9pP9pP9pP9pP9pP9pP9pP test@example.com
+    state: present
+    path: "{{ output_dir | expanduser }}/authorized_keys"
+    exclusive: true
+  register: mixed_source_result
+
+- name: Get the file content for mixed source verification
+  ansible.builtin.command: /bin/cat "{{ output_dir | expanduser }}/authorized_keys"
+  changed_when: false
+  register: mixed_file_content
+
+- name: Assert mixed sources were merged and processed correctly
+  ansible.builtin.assert:
+    that:
+      - mixed_source_result.changed == True
+      - mixed_file_content.stdout_lines | length == 3
+      - "'test1@example.com' in mixed_file_content.stdout"
+      - "'test@example.com' in mixed_file_content.stdout"


### PR DESCRIPTION
SUMMARY
This PR fixes a bug in the authorized_key module where providing multiple key sources (URLs or file paths) separated by newlines would fail or only process the first source.

The module's intake logic was previously "greedy," attempting to treat the entire multi-line string as a single URL if it started with http. This refactor ensures that the key parameter is split into individual lines first, allowing each source to be resolved independently (fetched, read, or treated as a raw key) before being merged into the final authorized_keys file.

Fixes #684 
Signed-off-by: Jason Hall jason.kei.hall@gmail.com

ISSUE TYPE
Bugfix Pull Request

COMPONENT NAME
plugins/modules/authorized_key.py
tests/integration/targets/authorized_key/tasks/multiple_keys.yml 
changelogs/fragments/684-fix-mixed-authorized-key-sources.yaml