### PR TITLE
Use password from command line through play context

### DIFF
--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -342,7 +342,9 @@ class ActionModule(ActionBase):
 
         # Determine if we need a user@ and a password
         user = None
-        password = task_vars.get('ansible_ssh_pass', None) or task_vars.get('ansible_password', None) or self._play_context.password
+        password = (task_vars.get('ansible_ssh_pass', None)
+                    or task_vars.get('ansible_password', None)
+                    or self._play_context.password)
         if not dest_is_local:
             # Src and dest rsync "path" handling
             if boolean(_tmp_args.get('set_remote_user', 'yes'), strict=False):
@@ -372,7 +374,9 @@ class ActionModule(ActionBase):
                 src = self._process_origin(src_host, src, user)
                 dest = self._process_remote(_tmp_args, dest_host, dest, user, inv_port in localhost_ports)
 
-            password = dest_host_inventory_vars.get('ansible_ssh_pass', None) or dest_host_inventory_vars.get('ansible_password', None) or self._play_context.password
+            password = (dest_host_inventory_vars.get('ansible_ssh_pass', None)
+                        or dest_host_inventory_vars.get('ansible_password', None)
+                        or self._play_context.password)
             if self._templar is not None:
                 password = self._templar.template(password)
         else:

--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -342,7 +342,7 @@ class ActionModule(ActionBase):
 
         # Determine if we need a user@ and a password
         user = None
-        password = task_vars.get('ansible_ssh_pass', None) or task_vars.get('ansible_password', None)
+        password = task_vars.get('ansible_ssh_pass', None) or task_vars.get('ansible_password', None) or self._play_context.password
         if not dest_is_local:
             # Src and dest rsync "path" handling
             if boolean(_tmp_args.get('set_remote_user', 'yes'), strict=False):
@@ -372,7 +372,7 @@ class ActionModule(ActionBase):
                 src = self._process_origin(src_host, src, user)
                 dest = self._process_remote(_tmp_args, dest_host, dest, user, inv_port in localhost_ports)
 
-            password = dest_host_inventory_vars.get('ansible_ssh_pass', None) or dest_host_inventory_vars.get('ansible_password', None)
+            password = dest_host_inventory_vars.get('ansible_ssh_pass', None) or dest_host_inventory_vars.get('ansible_password', None) or self._play_context.password
             if self._templar is not None:
                 password = self._templar.template(password)
         else:


### PR DESCRIPTION
Added fallback for password retrieval in synchronize.py

##### SUMMARY
This change will avoid separately asking for rsync password if --ask-pass or --connection-password-file is specified, it will use the connection password already provided. Getting the password from task vars is tried before, so there shouldn't be any negative impact on such existing use cases.

See also
https://www.reddit.com/r/ansible/comments/15zc1f0/synchronize_play_reasks_for_password_after/

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
synchronize

