### PR TITLE
Remove shell override in synchronize action plugin

### DIFF
--- a/plugins/action/synchronize.py
+++ b/plugins/action/synchronize.py
@@ -17,8 +17,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import os.path
-
 from ansible import constants as C
 from ansible.module_utils.six import string_types
 from ansible.module_utils.six.moves import shlex_quote
@@ -301,8 +299,6 @@ class ActionModule(ActionBase):
                         break
                 if localhost_shell:
                     break
-            else:
-                localhost_shell = os.path.basename(C.DEFAULT_EXECUTABLE)
             self._play_context.shell = localhost_shell
 
             # Unlike port, there can be only one executable

--- a/tests/unit/plugins/action/fixtures/synchronize/basic/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic/meta.yaml
@@ -11,7 +11,8 @@ hostvars:
 asserts:
   - hasattr(SAM._connection, 'ismock')
   - SAM._connection.transport == 'local'
-  - self._play_context.shell == 'sh'
+  - self._play_context.shell == None
+  - self._play_context.executable == '/bin/sh'
   - self.execute_called
   - self.final_module_args['_local_rsync_path'] == 'rsync'
   - self.final_module_args['src'] == '/tmp/deleteme'

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_become/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_become/meta.yaml
@@ -32,7 +32,8 @@ asserts:
   - self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'
   - self.task.become == True
   - self.task.become_user == None
-  - self._play_context.shell == 'sh'
+  - self._play_context.shell == None
+  - self._play_context.executable == '/bin/sh'
   - self._play_context.remote_addr == 'el6host'
   - self._play_context.remote_user == 'root'
   - self._play_context.become == False

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_become_cli/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_become_cli/meta.yaml
@@ -32,7 +32,8 @@ asserts:
   - self.final_module_args['dest'] == 'root@el6host:/tmp/deleteme'
   - self.task.become == None
   - self.task.become_user == None
-  - self._play_context.shell == 'sh'
+  - self._play_context.shell == None
+  - self._play_context.executable == '/bin/sh'
   - self._play_context.remote_addr == 'el6host'
   - self._play_context.remote_user == 'root'
   - self._play_context.become == False

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant/meta.yaml
@@ -22,7 +22,8 @@ asserts:
   - self.final_module_args['dest_port'] == 2202
   - self.final_module_args['src'] == '/tmp/deleteme'
   - self.final_module_args['dest'] == 'vagrant@127.0.0.1:/tmp/deleteme'
-  - self._play_context.shell == 'sh'
+  - self._play_context.shell == None
+  - self._play_context.executable == '/bin/sh'
   - self._play_context.remote_addr == '127.0.0.1'
   - self._play_context.remote_user == 'vagrant'
   - self._play_context.become == False

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_become_cli/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_become_cli/meta.yaml
@@ -25,7 +25,8 @@ asserts:
   - self.final_module_args['dest_port'] == 2202
   - self.final_module_args['src'] == '/tmp/deleteme'
   - self.final_module_args['dest'] == 'vagrant@127.0.0.1:/tmp/deleteme'
-  - self._play_context.shell == 'sh'
+  - self._play_context.shell == None
+  - self._play_context.executable == '/bin/sh'
   - self._play_context.remote_addr == '127.0.0.1'
   - self._play_context.remote_user == 'vagrant'
   - self._play_context.become == False

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_sudo/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_vagrant_sudo/meta.yaml
@@ -22,7 +22,8 @@ asserts:
   - self.final_module_args['dest_port'] == 2202
   - self.final_module_args['src'] == '/tmp/deleteme'
   - self.final_module_args['dest'] == 'vagrant@127.0.0.1:/tmp/deleteme'
-  - self._play_context.shell == 'sh'
+  - self._play_context.shell == None
+  - self._play_context.executable == '/bin/sh'
   - self._play_context.remote_addr == '127.0.0.1'
   - self._play_context.remote_user == 'vagrant'
   - self._play_context.become == False

--- a/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/meta.yaml
+++ b/tests/unit/plugins/action/fixtures/synchronize/basic_with_private_key/meta.yaml
@@ -18,7 +18,8 @@ task_args:
 asserts:
   - hasattr(SAM._connection, 'ismock')
   - SAM._connection.transport == 'local'
-  - self._play_context.shell == 'sh'
+  - self._play_context.shell == None
+  - self._play_context.executable == '/bin/sh'
   - self.execute_called
   - self.final_module_args['_local_rsync_path'] == 'rsync'
   - self.final_module_args['src'] == '/tmp/deleteme'


### PR DESCRIPTION
##### SUMMARY

Setting the shell from the executable basename is technically wrong, Ansible will determine the right shell to use on its own so setting it to None is safer.

This should fix #392 and #79

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME
synchronize

##### ADDITIONAL INFORMATION

If Ansible's executable is changed ([DEFAULT_EXECUTABLE](https://docs.ansible.com/projects/ansible/latest/reference_appendices/config.html#default-executable)), `ansible.posix.synchronize` stops working because it tries to resolve the shell plugin to use from the basename of the executable. Since the default shell plugin is called `sh`, if the executable was changed to `/bin/bash`, the basename is `bash` but no shell plugin matches this exact name.

One workaround is to add variables to `localhost` in the inventory: `localhost ansible_shell_type=sh ansible_connection=local`, but I think this is a bug anyway.

This was initially introduced a while ago here https://github.com/ansible/ansible/commit/2c825539ffb737051add23dbb9f16a5fef24e469, maybe at the time Ansible didn't resolve shells correctly?

But if `shell` is instead set to `None` in the play context then the connection plugin becomes responsible for resolving and setting it, and it does it properly: https://github.com/ansible/ansible/blob/99708930841723f3ecc20e95e82a0cd780003dbd/lib/ansible/plugins/connection/__init__.py#L98 (and especially using [get_shell_plugin](https://github.com/ansible/ansible/blob/99708930841723f3ecc20e95e82a0cd780003dbd/lib/ansible/plugins/loader.py#L91) since the action module sets `executable`, which is indeed the right behavior I believe)

Regarding the tests: I don't think this can really be tested given that the connection is mocked in `plugins/action/test_synchronize.py`, I updated the fixtures to at least validate that `executable` is properly set however.