### PR TITLE
firewalld_info: Use module.warn

### DIFF
--- a/changelogs/fragments/firewalld_info_warnings.yml
+++ b/changelogs/fragments/firewalld_info_warnings.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - firewalld_info - use module.warn instead of passing `warnings` to `exit_json` (https://github.com/ansible-collections/ansible.posix/issues/710).

--- a/plugins/modules/firewalld_info.py
+++ b/plugins/modules/firewalld_info.py
@@ -333,10 +333,6 @@ def main():
     if not HAS_FIREWALLD:
         module.fail_json(msg=missing_required_lib('python-firewall'))
 
-    # If you want to show warning messages in the task running process,
-    # you can append the message to the 'warn' list.
-    warn = list()
-
     try:
         client = fw_client.FirewallClient()
 
@@ -356,8 +352,7 @@ def main():
             collect_zones = list(set(specified_zones) & set(all_zones))
             ignore_zones = list(set(specified_zones) - set(collect_zones))
             if ignore_zones:
-                warn.append(
-                    'Please note: zone:(%s) have been ignored in the gathering process.' % ','.join(ignore_zones))
+                module.warn(f'Please note: zone:({",".join(ignore_zones)}) have been ignored in the gathering process.')
         else:
             collect_zones = get_all_zones(client)
 
@@ -396,7 +391,6 @@ def main():
     result['collected_zones'] = collect_zones
     result['undefined_zones'] = ignore_zones
     result['firewalld_info'] = firewalld_info
-    result['warnings'] = warn
     module.exit_json(**result)
 
 

--- a/tests/integration/targets/firewalld_info/tasks/run_tests_in_started.yml
+++ b/tests/integration/targets/firewalld_info/tasks/run_tests_in_started.yml
@@ -20,6 +20,7 @@
 - name: Assert turn active_zones true
   ansible.builtin.assert:
     that:
+      - result.collected_zones == ['public']
 
 - name: Ensure firewalld_zones with zone list
   ansible.posix.firewalld_info:
@@ -31,3 +32,6 @@
 - name: Assert specified zones
   ansible.builtin.assert:
     that:
+      - result.collected_zones == ['public']
+      - result.undefined_zones == ['invalid_zone']
+      - '"invalid_zone" in result.warnings[0]'


### PR DESCRIPTION
##### SUMMARY

* Use module.warn to display warnings instead of module.exit_json

Fixes: #710

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/firewalld_info_warnings.yml
plugins/modules/firewalld_info.py


