### PR TITLE
Removed ANSIBLE_METADATA from remaining plugins

### DIFF
--- a/changelogs/fragments/ansible_metadata_removed.yml
+++ b/changelogs/fragments/ansible_metadata_removed.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+    - removed ANSIBLE_METADATA from remaining plugins.

--- a/plugins/callback/cgroup_perf_recap.py
+++ b/plugins/callback/cgroup_perf_recap.py
@@ -6,9 +6,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
     name: cgroup_perf_recap

--- a/plugins/modules/rhel_rpm_ostree.py
+++ b/plugins/modules/rhel_rpm_ostree.py
@@ -7,9 +7,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---

--- a/plugins/modules/rpm_ostree_upgrade.py
+++ b/plugins/modules/rpm_ostree_upgrade.py
@@ -7,9 +7,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
 
 DOCUMENTATION = '''
 ---


### PR DESCRIPTION
##### SUMMARY

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/ansible_metadata_removed.yml
plugins/callback/cgroup_perf_recap.py
plugins/modules/rhel_rpm_ostree.py
plugins/modules/rpm_ostree_upgrade.py


