### PR TITLE
firewalld_info: Use PY2 compatible syntax

### DIFF
--- a/changelogs/fragments/firewalld_info_warnings.yml
+++ b/changelogs/fragments/firewalld_info_warnings.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-    - firewalld_info - use module.warn instead of passing `warnings` to `exit_json` (https://github.com/ansible-collections/ansible.posix/issues/710).
+    - firewalld_info - use module.warn instead of passing ``warnings`` to ``exit_json`` (https://github.com/ansible-collections/ansible.posix/issues/710).

--- a/plugins/modules/firewalld_info.py
+++ b/plugins/modules/firewalld_info.py
@@ -352,7 +352,7 @@ def main():
             collect_zones = list(set(specified_zones) & set(all_zones))
             ignore_zones = list(set(specified_zones) - set(collect_zones))
             if ignore_zones:
-                module.warn(f'Please note: zone:({",".join(ignore_zones)}) have been ignored in the gathering process.')
+                module.warn('Please note: zone:(%s) have been ignored in the gathering process.' % ", ".join(ignore_zones))
         else:
             collect_zones = get_all_zones(client)
 


### PR DESCRIPTION
##### SUMMARY

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
changelogs/fragments/firewalld_info_warnings.yml
plugins/modules/firewalld_info.py


