### PR TITLE
authorized_key: Use loop instead of with_file in example

### DIFF
--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -121,10 +121,10 @@ EXAMPLES = r'''
   ansible.posix.authorized_key:
     user: deploy
     state: present
-    key: '{{ item }}'
-  with_file:
-    - public_keys/doe-jane
-    - public_keys/doe-john
+    key: "{{ lookup('file', item) }}"
+    loop:
+      - public_keys/doe-jane
+      - public_keys/doe-john
 
 - name: Set authorized key defining key options
   ansible.posix.authorized_key:


### PR DESCRIPTION
##### SUMMARY

Fixes: #607

Signed-off-by: Abhijeet Kasurde <Akasurde@redhat.com>

##### ISSUE TYPE
- Bugfix Pull Request




##### COMPONENT NAME
plugins/modules/authorized_key.py


