### PR TITLE
docs: added attributes metadata for check_mode support (fixes #643)

### DIFF
--- a/changelogs/fragments/643-sysctl-docs.yml
+++ b/changelogs/fragments/643-sysctl-docs.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - sysctl - added the attributes section to the module documentation to reflect check_mode support (https://github.com/ansible-collections/ansible.posix/issues/643).

--- a/plugins/modules/sysctl.py
+++ b/plugins/modules/sysctl.py
@@ -56,6 +56,17 @@ options:
             - Verify token value with the sysctl command and set with C(-w) if necessary.
         type: bool
         default: false
+attributes:
+  check_mode:
+    support: full
+    description: Can run in check_mode and return changed status prediction without modifying target.
+  diff_mode:
+    support: none
+    description: Does not support differences output.
+  platform:
+    platforms: posix
+    support: full
+    description: Supported on POSIX-compliant systems.
 author:
 - David CHANIAL (@davixx)
 '''


### PR DESCRIPTION
##### SUMMARY
Updates sysctl module documentation to add attributes metadata for check_mode support.

Resurrected from #697

Fixes #643
  
##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
sysctl

##### ADDITIONAL INFORMATION
```paste below
```
