### PR TITLE
mount: Update line splitting logic

### DIFF
--- a/changelogs/fragments/743-mount-fix-hash-in-device-specs.yml
+++ b/changelogs/fragments/743-mount-fix-hash-in-device-specs.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - mount - fixed incorrect comment handling introduced in commit 8e34860 that broke device specifications containing ``#`` characters (e.g., SSHFS ``sshfs#user@host:path``) by incorrectly stripping everything after the first ``#``. The module now matches libmount behavior by only treating ``#`` at the start of a line as a comment (https://github.com/ansible-collections/ansible.posix/issues/743).

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -302,7 +302,7 @@ def _set_mount_save_old(module, args):
 
             continue
 
-        fields = line.split('#')[0].split()
+        fields = line.split()[:6]
 
         # Check if we got a valid line for splitting
         # (on Linux the 5th and the 6th field is optional)


### PR DESCRIPTION
##### SUMMARY
Fix incorrect fstab comment handling that breaks device specifications containing `#` characters (e.g., SSHFS `sshfs#user@host:path`).

The fix in commit 8e34860 for issue #595 uses `line.split('#')[0]` which incorrectly treats any `#` in a line as starting a comment. This breaks valid fstab entries where `#` is part of the device specification.

**Important context:** Issue #595 was based on a misunderstanding. End-of-line comments are NOT supported in fstab - libmount only treats `#` at the start of a line as a comment. What appeared to "work" in #595 was simply that libmount parses exactly 6 fields and ignores anything beyond field 6, regardless of whether it starts with `#`.

This PR changes the parsing to match libmount's actual behavior:
- Only treat `#` at line start (after whitespace) as a comment
- Parse maximum 6 fields and ignore extras
- Preserve `#` characters within field values

Fixes #743 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
mount

##### ADDITIONAL INFORMATION
**Before (broken):**
```python
fields = line.split('#')[0].split()
```

**After (correct):**
```python
stripped = line.strip()
if stripped.startswith('#') or not stripped:
    to_write.append(line)
    continue
fields = stripped.split()[:6]
```

**Impact:** This fixes SSHFS mounts, CIFS mounts with `#` in paths, and any filesystem using `#` in device specifications.

**Testing:**
```yaml
- name: Test SSHFS mount is idempotent
  ansible.posix.mount:
    src: "sshfs#user@host:/path"
    path: /mnt/remote
    fstype: fuse3
    opts: allow_root,_netdev
    state: present
```

First run: creates entry correctly
Second run: `changed=false` (idempotent)

**References:**
- libmount source: https://github.com/util-linux/util-linux/blob/master/libmount/src/tab_parse.c
  - `is_comment_line()`: Only checks for `#` at start of line
  - `mnt_parse_table_line()`: Parses exactly 6 fields
- fstab(5) man pages: "Lines beginning with '#' are comments"