### PR TITLE
docs: added attributes metadata for check_mode support (fixes #649)

### DIFF
--- a/changelogs/fragments/649-mount-docs.yml
+++ b/changelogs/fragments/649-mount-docs.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - mount - added the attributes section to the module documentation to reflect check_mode support (https://github.com/ansible-collections/ansible.posix/issues/649).

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -138,6 +138,17 @@ notes:
   - Using O(state=remounted) with O(opts) set may create unexpected results based on
     the existing options already defined on mount, so care should be taken to
     ensure that conflicting options are not present before hand.
+attributes:
+  check_mode:
+    support: full
+    description: Can run in check_mode and return changed status prediction without modifying target.
+  diff_mode:
+    support: none
+    description: Does not support differences output.
+  platform:
+    platforms: posix
+    support: full
+    description: Supported on POSIX-compliant systems.
 '''
 
 EXAMPLES = r'''


### PR DESCRIPTION
Fixes #649.

Mirrors @pkingstonxyz's sysctl docs fix in #741: adds an `attributes:` block to the mount module documentation declaring check_mode (full), diff_mode (none), and platform (posix) support. The values match observed behavior in `mount.py`:

- `AnsibleModule(..., supports_check_mode=True)` (mount.py:782)
- No `diff` output produced anywhere in the module, so `diff_mode: none`
- POSIX-only module by definition

Changelog fragment included per project convention.