### PR TITLE
[CI] AZP bump test container version to 8.0.0

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -37,8 +37,9 @@ variables:
 resources:
   containers:
     - container: default
+      image: quay.io/ansible/azure-pipelines-test-container:8.0.0
+    - container: legacy
       image: quay.io/ansible/azure-pipelines-test-container:7.0.0
-
 pool: Standard
 
 stages:
@@ -128,6 +129,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
+          container: legacy
           nameFormat: "{0}"
           testFormat: 2.17/{0}
           targets:
@@ -145,6 +147,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
+          container: legacy
           nameFormat: "{0}"
           testFormat: 2.16/{0}
           targets:
@@ -237,6 +240,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
+          container: legacy
           testFormat: 2.17/linux/{0}/1
           targets:
             - name: Fedora 39
@@ -250,6 +254,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
+          container: legacy
           testFormat: 2.16/linux/{0}/1
           targets:
             - name: Fedora 38
@@ -347,6 +352,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
+          container: legacy
           testFormat: 2.17/{0}/1
           targets:
             - name: RHEL 10.0
@@ -360,6 +366,7 @@ stages:
     jobs:
       - template: templates/matrix.yml
         parameters:
+          container: legacy
           testFormat: 2.16/{0}/1
           targets:
             - name: RHEL 10.1

--- a/.azure-pipelines/templates/matrix.yml
+++ b/.azure-pipelines/templates/matrix.yml
@@ -14,6 +14,12 @@ parameters:
     type: object
     default: []
 
+  # An optional container resource name to use for the test jobs.
+  # Defaults to "default" if not specified.
+  - name: container
+    type: string
+    default: default
+
   # An optional format string used to generate the job name.
   # - {0} is the name of an item in the targets list.
   - name: nameFormat
@@ -43,6 +49,7 @@ parameters:
 jobs:
   - template: test.yml
     parameters:
+      container: ${{ parameters.container }}
       jobs:
         - ${{ if eq(length(parameters.groups), 0) }}:
           - ${{ each target in parameters.targets }}:

--- a/.azure-pipelines/templates/test.yml
+++ b/.azure-pipelines/templates/test.yml
@@ -7,11 +7,17 @@ parameters:
   - name: jobs
     type: object
 
+  # An optional container resource name to use for the test jobs.
+  # Defaults to "default" if not specified.
+  - name: container
+    type: string
+    default: default
+
 jobs:
   - ${{ each job in parameters.jobs }}:
     - job: test_${{ replace(replace(replace(job.test, '/', '_'), '.', '_'), '-', '_') }}
       displayName: ${{ job.name }}
-      container: default
+      container: ${{ parameters.container }}
       workspace:
         clean: all
       steps:

--- a/changelogs/fragments/751_ci_test_container_update.yml
+++ b/changelogs/fragments/751_ci_test_container_update.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Update Azure Pipelines test container to 8.0.0 and use legacy container for ansible-core 2.16/2.17.


### PR DESCRIPTION
##### SUMMARY

Addressing https://github.com/ansible-collections/news-for-maintainers/issues/74

- Bump test container version to 8.0.0 for Ansible Core 2.18+
- Keep using 7.0.0 for Ansible Core 2.16 and 2.17. Both versions don't support Python3.13.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- ansible.posix

##### ADDITIONAL INFORMATION
```paste below
None
```
