### PR TITLE
[CI] Replace remote test env RHEL9.7 and 10.1 with 9.8 and 10.2

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -271,10 +271,10 @@ stages:
         parameters:
           testFormat: devel/{0}/1
           targets:
-            - name: RHEL 10.1
-              test: rhel/10.1
-            - name: RHEL 9.7
-              test: rhel/9.7
+            - name: RHEL 10.2
+              test: rhel/10.2
+            - name: RHEL 9.8
+              test: rhel/9.8
             - name: FreeBSD 14.4
               test: freebsd/14.4
             - name: FreeBSD 15.0

--- a/changelogs/fragments/763_ci_azp_update_devel.yml
+++ b/changelogs/fragments/763_ci_azp_update_devel.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Replace AZP remote test RHEL9.7 and RHEL10.1 with 9.8 and 10.2 for devel branch.


### PR DESCRIPTION
##### SUMMARY
Update AZP remote test for the devel branch.

- Replace 9.7 with 9.8
- Replace 10.1 with 10.2
- Addresses https://github.com/ansible/ansible/pull/87120

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
```paste below
None
```
