### PR TITLE
fix(callback): align profile_tasks recap output width

### DIFF
--- a/changelogs/fragments/773_profile_tasks_display_alignment.yml
+++ b/changelogs/fragments/773_profile_tasks_display_alignment.yml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - profile_tasks callback - align TASKS RECAP output with ``display.banner()`` width instead of a hardcoded 79 columns (https://github.com/ansible-collections/ansible.posix/pull/773).
+minor_changes:
+  - profile_tasks callback - add ``truncate_task_names`` option (default ``false``) to ellipsize long task names in the TASKS RECAP summary (https://github.com/ansible-collections/ansible.posix/pull/773).

--- a/plugins/callback/profile_tasks.py
+++ b/plugins/callback/profile_tasks.py
@@ -63,6 +63,17 @@ DOCUMENTATION = '''
           - section: callback_profile_tasks
             key: datetime_format
         version_added: 3.0.0
+      truncate_task_names:
+        description:
+          - Truncate long task names in the TASKS RECAP summary with an ellipsis so rows stay within the terminal width.
+        type: bool
+        default: false
+        env:
+          - name: PROFILE_TASKS_TRUNCATE_TASK_NAMES
+        ini:
+          - section: callback_profile_tasks
+            key: truncate_task_names
+        version_added: 2.3.0
 '''
 
 EXAMPLES = '''
@@ -88,6 +99,7 @@ from datetime import datetime
 
 from functools import reduce
 from ansible.plugins.callback import CallbackBase
+from ansible.utils.display import get_text_width
 
 
 # define start time
@@ -102,16 +114,64 @@ def secondsToStr(t):
     return "%d:%02d:%02d.%03d" % tuple(reduce(rediv, [[t * 1000, ], 1000, 60, 60]))
 
 
-def filled(msg, fchar="*"):
-    if len(msg) == 0:
-        width = 79
+def filled(msg, columns, fchar="*"):
+    """Fill to the same width as display.banner() (columns + 1)."""
+    if not msg:
+        return fchar * (columns + 1)
+    try:
+        msg_width = get_text_width(msg)
+    except EnvironmentError:
+        msg_width = len(msg)
+    fill_len = columns - msg_width
+    if fill_len < 3:
+        fill_len = 3
+    return "%s %s" % (msg, fchar * fill_len)
+
+
+def _text_width(text):
+    try:
+        return get_text_width(text)
+    except EnvironmentError:
+        return len(text)
+
+
+def truncate_name(name, width):
+    if width <= 0:
+        return name
+    if _text_width(name) <= width:
+        return name
+    if width <= 3:
+        return name[:width]
+    ellipsis = '...'
+    for end in range(len(name), 0, -1):
+        candidate = name[:end] + ellipsis
+        if _text_width(candidate) <= width:
+            return candidate
+    return ellipsis
+
+
+def pad_to_display_width(text, width, fillchar='-'):
+    current = _text_width(text)
+    if current >= width:
+        return text
+    return text + fillchar * (width - current)
+
+
+def format_timing_row(task_name, elapsed, columns, truncate=False):
+    line_width = columns + 1
+    time_field_width = 9
+    name_field_width = line_width - time_field_width
+    if truncate:
+        task_name = truncate_name(task_name, name_field_width - 1)
+    prefix = task_name + u' '
+    gap = name_field_width - _text_width(prefix)
+    if gap == 1:
+        # A lone dash before the timing field looks like misaligned padding.
+        left = prefix + u' '
     else:
-        msg = "%s " % msg
-        width = 79 - len(msg)
-    if width < 3:
-        width = 3
-    filler = fchar * width
-    return "%s%s " % (msg, filler)
+        left = pad_to_display_width(prefix, name_field_width)
+    timing = u' {0:.02f}s'.format(elapsed)
+    return left + timing.rjust(time_field_width, u'-')
 
 
 def timestamp(self):
@@ -127,7 +187,10 @@ def tasktime(self):
     time_elapsed = secondsToStr((cdtn - dtn).total_seconds())
     time_total_elapsed = secondsToStr((cdtn - dt0).total_seconds())
     dtn = cdtn
-    return filled('%s (%s)%s%s' % (datetime_current, time_elapsed, ' ' * 7, time_total_elapsed))
+    return filled(
+        '%s (%s)%s%s' % (datetime_current, time_elapsed, ' ' * 7, time_total_elapsed),
+        self._display.columns,
+    )
 
 
 class CallbackModule(CallbackBase):
@@ -148,6 +211,7 @@ class CallbackModule(CallbackBase):
         self.summary_only = None
         self.task_output_limit = None
         self.datetime_format = None
+        self.truncate_task_names = None
 
         super(CallbackModule, self).__init__()
 
@@ -177,6 +241,8 @@ class CallbackModule(CallbackBase):
         if self.datetime_format is not None:
             if self.datetime_format == 'iso8601':
                 self.datetime_format = '%Y-%m-%dT%H:%M:%S.%f'
+
+        self.truncate_task_names = self.get_option('truncate_task_names')
 
     def _display_tasktime(self):
         if not self.summary_only:
@@ -210,11 +276,12 @@ class CallbackModule(CallbackBase):
         self._record_task(task)
 
     def v2_playbook_on_stats(self, stats):
-        # Align summary report header with other callback plugin summary
-        self._display.banner("TASKS RECAP")
+        columns = self._display.columns
+        line_width = columns + 1
+        self._display.display(filled("TASKS RECAP", columns))
 
         self._display.display(tasktime(self))
-        self._display.display(filled("", fchar="="))
+        self._display.display(filled("", columns, fchar="="))
 
         timestamp(self)
         self.current = None
@@ -234,7 +301,15 @@ class CallbackModule(CallbackBase):
 
         # Print the timings
         for uuid, result in results:
-            msg = u"{0:-<{2}}{1:->9}".format(result['name'] + u' ', u' {0:.02f}s'.format(result['elapsed']), self._display.columns - 9)
+            msg = format_timing_row(
+                result['name'],
+                result['elapsed'],
+                columns,
+                truncate=self.truncate_task_names,
+            )
             if 'path' in result:
-                msg += u"\n{0:-<{1}}".format(result['path'] + u' ', self._display.columns)
+                path_name = result['path']
+                if self.truncate_task_names:
+                    path_name = truncate_name(path_name, line_width - 1)
+                msg += u"\n%s" % pad_to_display_width(path_name + u' ', line_width)
             self._display.display(msg)

--- a/tests/unit/plugins/callback/test_profile_tasks.py
+++ b/tests/unit/plugins/callback/test_profile_tasks.py
@@ -1,0 +1,109 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.ansible.posix.tests.unit.compat import unittest
+from ansible.utils.display import get_text_width
+
+from ansible_collections.ansible.posix.plugins.callback.profile_tasks import (
+    filled,
+    format_timing_row,
+    pad_to_display_width,
+    truncate_name,
+)
+
+
+class ProfileTasksDisplayTestCase(unittest.TestCase):
+
+    COLUMNS = 79
+    LINE_WIDTH = COLUMNS + 1
+    # Reproducer from https://github.com/ansible-collections/ansible.posix/pull/773#issuecomment-5325694910
+    MAINTAINER_ASCII_LONG = (
+        '012345678901234567890123456789012345678901234567890'
+        '12345678901234567890123456789'
+    )
+    MAINTAINER_CJK_LONG = (
+        '零一二三四五六七八九零一二三四五六七八九'
+        '零一二三四五六七八九零一二三四五六七八九'
+    )
+    ASCII_LONG = MAINTAINER_ASCII_LONG
+    CJK_LONG = MAINTAINER_CJK_LONG
+
+    def test_filled_banner_matches_display_width(self):
+        line = filled('TASKS RECAP', self.COLUMNS)
+        self.assertEqual(get_text_width(line), self.LINE_WIDTH)
+        self.assertTrue(line.endswith('*'))
+
+    def test_filled_separator_matches_display_width(self):
+        line = filled('', self.COLUMNS, fchar='=')
+        self.assertEqual(get_text_width(line), self.LINE_WIDTH)
+        self.assertEqual(line, '=' * self.LINE_WIDTH)
+
+    def test_truncate_name_shortens_ascii_to_display_width(self):
+        truncated = truncate_name(self.ASCII_LONG, 71)
+        self.assertLessEqual(get_text_width(truncated), 71)
+        self.assertTrue(truncated.endswith('...'))
+
+    def test_truncate_name_shortens_cjk_to_display_width(self):
+        truncated = truncate_name(self.CJK_LONG, 71)
+        self.assertLessEqual(get_text_width(truncated), 71)
+        self.assertTrue(truncated.endswith('...'))
+
+    def test_truncate_name_leaves_short_names_unchanged(self):
+        short = 'Short task'
+        self.assertEqual(truncate_name(short, 71), short)
+        self.assertEqual(truncate_name(self.CJK_LONG[:5], 71), self.CJK_LONG[:5])
+
+    def test_format_timing_row_ascii_fits_terminal_width(self):
+        row = format_timing_row(self.ASCII_LONG, 0.01, self.COLUMNS, truncate=True)
+        self.assertEqual(get_text_width(row), self.LINE_WIDTH)
+        self.assertIn('0.01s', row)
+
+    def test_format_timing_row_cjk_fits_terminal_width(self):
+        row = format_timing_row(self.CJK_LONG, 0.01, self.COLUMNS, truncate=True)
+        self.assertEqual(get_text_width(row), self.LINE_WIDTH)
+        self.assertIn('0.01s', row)
+
+    def test_maintainer_cjk_reproducer_fits_under_len_budget_but_not_display_width(self):
+        self.assertEqual(len(self.MAINTAINER_CJK_LONG), 40)
+        self.assertEqual(get_text_width(self.MAINTAINER_CJK_LONG), 80)
+        self.assertGreater(len(self.MAINTAINER_CJK_LONG), 0)
+
+    def test_maintainer_cjk_reproducer_truncates_with_ellipsis(self):
+        truncated = truncate_name(self.MAINTAINER_CJK_LONG, 71)
+        self.assertLessEqual(get_text_width(truncated), 71)
+        self.assertTrue(truncated.endswith('...'))
+        self.assertNotEqual(truncated, self.MAINTAINER_CJK_LONG)
+
+    def test_maintainer_ascii_and_cjk_recap_rows_match_terminal_width(self):
+        ascii_row = format_timing_row(
+            self.MAINTAINER_ASCII_LONG, 0.01, self.COLUMNS, truncate=True,
+        )
+        cjk_row = format_timing_row(
+            self.MAINTAINER_CJK_LONG, 0.01, self.COLUMNS, truncate=True,
+        )
+        self.assertEqual(get_text_width(ascii_row), self.LINE_WIDTH)
+        self.assertEqual(get_text_width(cjk_row), self.LINE_WIDTH)
+        self.assertIn('...', ascii_row)
+        self.assertIn('...', cjk_row)
+
+    def test_format_timing_row_uses_dash_padding_for_timing_field(self):
+        row = format_timing_row('Short task', 0.01, self.COLUMNS, truncate=True)
+        self.assertTrue(row.endswith('--- 0.01s'))
+        self.assertEqual(get_text_width(row), self.LINE_WIDTH)
+
+    def test_pad_to_display_width_handles_cjk(self):
+        padded = pad_to_display_width(self.MAINTAINER_CJK_LONG[:5] + u' ', 71)
+        self.assertEqual(get_text_width(padded), 71)
+        self.assertTrue(padded.endswith('-'))
+
+    def test_format_timing_row_cjk_timing_suffix_matches_ascii(self):
+        ascii_row = format_timing_row(self.MAINTAINER_ASCII_LONG, 0.01, self.COLUMNS, truncate=True)
+        cjk_row = format_timing_row(self.MAINTAINER_CJK_LONG, 0.01, self.COLUMNS, truncate=True)
+        self.assertTrue(ascii_row.endswith('--- 0.01s'))
+        self.assertTrue(cjk_row.endswith('--- 0.01s'))
+        self.assertNotIn('----', cjk_row)
+        self.assertEqual(
+            get_text_width(ascii_row[:ascii_row.rindex('.')]),
+            get_text_width(cjk_row[:cjk_row.rindex('.')]),
+        )


### PR DESCRIPTION
## Summary

- `profile_tasks`: replace the hardcoded 79-column `filled()` width with `display.columns`, matching `display.banner()` fill rules (`columns + 1` visible width). Removes the trailing space `filled()` appended after the stars, which left the last `*` one column left of the TASK banner.
- `profile_tasks`: add `truncate_task_names` (default `false`) to ellipsize long task names in the TASKS RECAP summary. Enable with `PROFILE_TASKS_TRUNCATE_TASK_NAMES` or `callback_profile_tasks.truncate_task_names`.

The `ansible.posix.debug` PLAY RECAP alignment from an earlier revision of this PR is now in #778.

## Output

Captured from `playbooks/test/callback-plugins.yml` (80-column terminal, `columns=79`).

### Per-task timestamp (during play)

The visible lines below look almost identical in copy/paste. The misalignment is a single invisible trailing space on the timestamp line in 2.2.2. See line endings below.

Before (`ansible.posix` 2.2.2):

```
TASK [Short task] **************************************************************
Wednesday 22 July 2026  15:25:24 +0000 (0:00:01.242)       0:00:01.266 ********
```

After:

```
TASK [Short task] **************************************************************
Wednesday 22 July 2026  15:25:27 +0000 (0:00:01.228)       0:00:01.244 *********
```

Line endings (`cat -A` on the timestamp line only):

```
# before: eight stars, then a space, then end of line
... 0:00:01.266 ******** $

# after: nine stars, then end of line
... 0:00:01.244 *********$
```

### TASKS RECAP

Before: header/separator are 80 columns with a trailing space; timing rows are 79 columns. Long task names overflow.

```
TASKS RECAP ********************************************************************
Wednesday 22 July 2026  15:25:24 +0000 (0:00:00.382)       0:00:01.670 ********
=============================================================================== 
Duplicate --------------------------------------------------------------- 1.24s
This is a deliberately long task name used to test TASKS RECAP truncation behaviour --- 0.38s
```

After: all rows are 80 columns. Long names still print in full by default. With `truncate_task_names=true` they are ellipsized.

```
TASKS RECAP ********************************************************************
Wednesday 22 July 2026  15:25:27 +0000 (0:00:00.407)       0:00:01.681 *********
================================================================================
Duplicate ---------------------------------------------------------------- 1.23s
This is a deliberately long task name used to test TASKS RECAP truncation behaviour --- 0.41s
```

## Test plan

- [x] Run a playbook with `callbacks_enabled=ansible.posix.profile_tasks`
- [x] Verify TASK banner and profile_tasks timestamp lines end on the same star column (`cat -A` on the timestamp line)
- [x] Verify TASKS RECAP header, timestamp, separator, and timing rows are all the same width
- [x] Verify long task names are not truncated unless `truncate_task_names` is enabled
- [x] Verify duplicate-named tasks appear separately in TASKS RECAP (UUID tracking unchanged)