### PR TITLE
mount: Create a state like absent but keeps the mountpoint

### DIFF
--- a/changelogs/fragments/774_add_absent_mount.yml
+++ b/changelogs/fragments/774_add_absent_mount.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Introduce an option to remove only the mount and fstab entry but not the mountpoint  (https://github.com/ansible-collections/ansible.posix/issues/331)."

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -88,6 +88,13 @@ options:
         fail if multiple devices are mounted on the same mount point. Using
         V(absent) with a mount point that is not registered in the I(fstab) has
         no effect, use V(unmounted) instead.
+      - V(absent_mount) specifies that the mount point entry O(path) will be removed
+        from I(fstab) and will also unmount the mounted device. The associated
+        mountpoint will not be removed. A mounted device will be unmounted regardless 
+        of O(src) or its real source. V(absent_mount) does not unmount recursively, 
+        and the module will fail if multiple devices are mounted on the same mount
+        point. Using V(absent_mount) with a mount point that is not registered in the
+        I(fstab) has no effect, use V(unmounted) instead.
       - V(remounted) specifies that the device will be remounted for when you
         want to force a refresh on the mount itself (added in 2.9). This will
         always return RV(ignore:changed=true). If O(opts) is set, the options will be
@@ -102,7 +109,7 @@ options:
         mountpoint.
     type: str
     required: true
-    choices: [ absent, absent_from_fstab, mounted, present, unmounted, remounted, ephemeral ]
+    choices: [ absent, absent_from_fstab, absent_mount, mounted, present, unmounted, remounted, ephemeral ]
   fstab:
     description:
       - File to use instead of C(/etc/fstab).
@@ -169,6 +176,11 @@ EXAMPLES = r'''
   ansible.posix.mount:
     path: /tmp/mnt-pnt
     state: unmounted
+
+- name: Unmount a mounted volume and remove its fstab entry
+  ansible.posix.mount:
+    path: /tmp/mnt-pnt
+    state: absent_mount
 
 - name: Remount a mounted volume
   ansible.posix.mount:
@@ -777,7 +789,7 @@ def main():
             passno=dict(type='str', no_log=False, default='0'),
             src=dict(type='path'),
             backup=dict(type='bool', default=False),
-            state=dict(type='str', required=True, choices=['absent', 'absent_from_fstab', 'mounted', 'present', 'unmounted', 'remounted', 'ephemeral']),
+            state=dict(type='str', required=True, choices=['absent', 'absent_from_fstab', 'absent_mount', 'mounted', 'present', 'unmounted', 'remounted', 'ephemeral']),
         ),
         supports_check_mode=True,
         required_if=(
@@ -881,7 +893,7 @@ def main():
 
     if state == 'absent_from_fstab':
         name, changed = unset_mount(module, args)
-    elif state == 'absent':
+    elif state == 'absent' or state == 'absent_mount':
         name, changed = unset_mount(module, args)
 
         if changed and not module.check_mode:
@@ -892,7 +904,7 @@ def main():
                     module.fail_json(
                         msg="Error unmounting %s: %s" % (name, msg))
 
-            if os.path.exists(name):
+            if os.path.exists(name) and state == 'absent':
                 try:
                     os.rmdir(name)
                 except (OSError, IOError) as e:

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -789,8 +789,20 @@ def main():
             passno=dict(type='str', no_log=False, default='0'),
             src=dict(type='path'),
             backup=dict(type='bool', default=False),
-            state=dict(type='str', required=True,
-                      choices=['absent', 'absent_from_fstab', 'absent_mount', 'mounted', 'present', 'unmounted', 'remounted', 'ephemeral']),
+            state=dict(
+                type='str',
+                required=True,
+                choices=[
+                    'absent',
+                    'absent_from_fstab',
+                    'absent_mount',
+                    'mounted',
+                    'present',
+                    'unmounted',
+                    'remounted',
+                    'ephemeral'
+                ]
+            ),
         ),
         supports_check_mode=True,
         required_if=(

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -88,12 +88,12 @@ options:
         fail if multiple devices are mounted on the same mount point. Using
         V(absent) with a mount point that is not registered in the I(fstab) has
         no effect, use V(unmounted) instead.
-      - V(absent_mount) specifies that the mount point entry O(path) will be removed
+      - V(absent_keep_mountpoint) specifies that the mount point entry O(path) will be removed
         from I(fstab) and will also unmount the mounted device. The associated
         mountpoint will not be removed. A mounted device will be unmounted regardless
-        of O(src) or its real source. V(absent_mount) does not unmount recursively,
+        of O(src) or its real source. V(absent_keep_mountpoint) does not unmount recursively,
         and the module will fail if multiple devices are mounted on the same mount
-        point. Using V(absent_mount) with a mount point that is not registered in the
+        point. Using V(absent_keep_mountpoint) with a mount point that is not registered in the
         I(fstab) has no effect, use V(unmounted) instead.
       - V(remounted) specifies that the device will be remounted for when you
         want to force a refresh on the mount itself (added in 2.9). This will
@@ -109,7 +109,7 @@ options:
         mountpoint.
     type: str
     required: true
-    choices: [ absent, absent_from_fstab, absent_mount, mounted, present, unmounted, remounted, ephemeral ]
+    choices: [ absent, absent_from_fstab, absent_keep_mountpoint, mounted, present, unmounted, remounted, ephemeral ]
   fstab:
     description:
       - File to use instead of C(/etc/fstab).
@@ -180,7 +180,7 @@ EXAMPLES = r'''
 - name: Unmount a mounted volume and remove its fstab entry
   ansible.posix.mount:
     path: /tmp/mnt-pnt
-    state: absent_mount
+    state: absent_keep_mountpoint
 
 - name: Remount a mounted volume
   ansible.posix.mount:
@@ -795,7 +795,7 @@ def main():
                 'choices': [
                     'absent',
                     'absent_from_fstab',
-                    'absent_mount',
+                    'absent_keep_mountpoint',
                     'mounted',
                     'present',
                     'unmounted',
@@ -906,7 +906,7 @@ def main():
 
     if state == 'absent_from_fstab':
         name, changed = unset_mount(module, args)
-    elif state == 'absent' or state == 'absent_mount':
+    elif state == 'absent' or state == 'absent_keep_mountpoint':
         name, changed = unset_mount(module, args)
 
         if changed and not module.check_mode:

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -90,8 +90,8 @@ options:
         no effect, use V(unmounted) instead.
       - V(absent_mount) specifies that the mount point entry O(path) will be removed
         from I(fstab) and will also unmount the mounted device. The associated
-        mountpoint will not be removed. A mounted device will be unmounted regardless 
-        of O(src) or its real source. V(absent_mount) does not unmount recursively, 
+        mountpoint will not be removed. A mounted device will be unmounted regardless
+        of O(src) or its real source. V(absent_mount) does not unmount recursively,
         and the module will fail if multiple devices are mounted on the same mount
         point. Using V(absent_mount) with a mount point that is not registered in the
         I(fstab) has no effect, use V(unmounted) instead.
@@ -789,7 +789,8 @@ def main():
             passno=dict(type='str', no_log=False, default='0'),
             src=dict(type='path'),
             backup=dict(type='bool', default=False),
-            state=dict(type='str', required=True, choices=['absent', 'absent_from_fstab', 'absent_mount', 'mounted', 'present', 'unmounted', 'remounted', 'ephemeral']),
+            state=dict(type='str', required=True,
+                      choices=['absent', 'absent_from_fstab', 'absent_mount', 'mounted', 'present', 'unmounted', 'remounted', 'ephemeral']),
         ),
         supports_check_mode=True,
         required_if=(

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -789,10 +789,10 @@ def main():
             passno=dict(type='str', no_log=False, default='0'),
             src=dict(type='path'),
             backup=dict(type='bool', default=False),
-            state=dict(
-                type='str',
-                required=True,
-                choices=[
+            state={
+                'type': 'str',
+                'required': True,
+                'choices': [
                     'absent',
                     'absent_from_fstab',
                     'absent_mount',
@@ -802,7 +802,7 @@ def main():
                     'remounted',
                     'ephemeral'
                 ]
-            ),
+            },
         ),
         supports_check_mode=True,
         required_if=(

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -339,7 +339,7 @@
       - not dest_stat['stat']['exists']
   when: ansible_system in ('FreeBSD', 'Linux')
 
-# unmount (absent_mount)
+# unmount (absent_keep_mountpoint)
 - name: Bind mount a filesystem (Linux)
   ansible.posix.mount:
     src: '{{ output_dir }}/mount_source'
@@ -362,7 +362,7 @@
 - name: Unmount the bind mount while keeping the mountpoint
   ansible.posix.mount:
     name: '{{ output_dir }}/mount_dest'
-    state: absent_mount
+    state: absent_keep_mountpoint
   when: ansible_system in ('Linux', 'FreeBSD')
   register: unmount_result
 

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -350,6 +350,15 @@
   when: ansible_system == 'Linux'
   register: bind_result_linux
 
+- name: Bind mount a filesystem (FreeBSD)
+  ansible.posix.mount:
+    src: '{{ output_dir }}/mount_source'
+    name: '{{ output_dir }}/mount_dest'
+    state: mounted
+    fstype: nullfs
+  when: ansible_system == 'FreeBSD'
+  register: bind_result_freebsd
+
 - name: Unmount the bind mount while keeping the mountpoint
   ansible.posix.mount:
     name: '{{ output_dir }}/mount_dest'

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -297,10 +297,17 @@
   when: ansible_system in ('FreeBSD', 'Linux')
   register: dest_stat
 
+- name: Check if the mountpoint still exists
+  ansible.builtin.stat:
+    path: '{{ output_dir }}/mount_dest'
+  when: ansible_system in ('FreeBSD', 'Linux')
+  register: mountpoint_stat
+
 - name: Check that we did not unmount
   ansible.builtin.assert:
     that:
       - unmount_result['changed']
+      - mountpoint_stat['stat']['exists']
       - dest_stat['stat']['exists']
   when: ansible_system in ('FreeBSD', 'Linux')
 
@@ -318,10 +325,56 @@
   when: ansible_system in ('FreeBSD', 'Linux')
   register: dest_stat
 
+- name: Check that the mountpoint no longer exists
+  ansible.builtin.stat:
+    path: '{{ output_dir }}/mount_dest'
+  when: ansible_system in ('FreeBSD', 'Linux')
+  register: mountpoint_stat
+
 - name: Check that we unmounted
   ansible.builtin.assert:
     that:
       - unmount_result['changed']
+      - not mountpoint_stat['stat']['exists']
+      - not dest_stat['stat']['exists']
+  when: ansible_system in ('FreeBSD', 'Linux')
+
+# unmount (absent_mount)
+- name: Bind mount a filesystem (Linux)
+  ansible.posix.mount:
+    src: '{{ output_dir }}/mount_source'
+    name: '{{ output_dir }}/mount_dest'
+    state: mounted
+    fstype: None
+    opts: bind
+  when: ansible_system == 'Linux'
+  register: bind_result_linux
+
+- name: Unmount the bind mount while keeping the mountpoint
+  ansible.posix.mount:
+    name: '{{ output_dir }}/mount_dest'
+    state: absent_mount
+  when: ansible_system in ('Linux', 'FreeBSD')
+  register: unmount_result
+
+- name: Make sure the file no longer exists in dest
+  ansible.builtin.stat:
+    path: '{{ output_dir }}/mount_dest/test_file'
+  when: ansible_system in ('FreeBSD', 'Linux')
+  register: dest_stat
+
+- name: Check if the mountpoint still exists
+  ansible.builtin.stat:
+    path: '{{ output_dir }}/mount_dest'
+  when: ansible_system in ('FreeBSD', 'Linux')
+  register: mountpoint_stat
+
+- name: Check that we unmounted and that the mountpoint still exists
+  ansible.builtin.assert:
+    that:
+      - (ansible_system == 'Linux' and bind_result_linux['changed']) or (ansible_system == 'FreeBSD' and bind_result_freebsd['changed'])
+      - unmount_result['changed']
+      - mountpoint_stat['stat']['exists']
       - not dest_stat['stat']['exists']
   when: ansible_system in ('FreeBSD', 'Linux')
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Currently, `state: absent` will remove the mount, the entry in fstab, and the mountpoint
  - Users might not want to run rmdir on the mountpoint. Maybe they mounted over something else. 
- We want to keep backwards compatibility.
  - If we added a new option for removing a mountpoint, it would end up changing how an existing state works.
  - By adding a new state, users can just opt into the new state.
    - I decided to call the state `absent_mount`.
    - `absent` here means that the mountpoint, fstab entry, and mount are all removed
    - `absent_mount` means that only the mount is removed (to include the fstab entry), and the mountpoint stays  
- Fixes #331 
- Addresses same concerns as #569 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mount

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
# See integration tests
```
