### PR TITLE
authorized_key: Preserve keys without comments

### DIFF
--- a/changelogs/fragments/777-authorized-key-empty-comment.yml
+++ b/changelogs/fragments/777-authorized-key-empty-comment.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ansible.posix.authorized_key - avoid adding trailing whitespace when serializing keys without comments (https://github.com/ansible-collections/ansible.posix/issues/750).

--- a/plugins/modules/authorized_key.py
+++ b/plugins/modules/authorized_key.py
@@ -559,8 +559,10 @@ def serialize(keys):
 
             if key_type == 'skipped':
                 key_line = key[0]
-            else:
+            elif comment:
                 key_line = "%s%s %s %s\n" % (option_str, key_type, keyhash, comment)
+            else:
+                key_line = "%s%s %s\n" % (option_str, key_type, keyhash)
         except Exception:
             key_line = key
         lines.append(key_line)

--- a/tests/integration/targets/authorized_key/tasks/empty_comment.yml
+++ b/tests/integration/targets/authorized_key/tasks/empty_comment.yml
@@ -1,0 +1,47 @@
+---
+# -------------------------------------------------------------
+# keys without comments
+
+- name: Create an authorized keys file with a key without a comment
+  ansible.builtin.copy:
+    content: "ssh-ed25519 DATA_WITHOUT_COMMENT\n"
+    dest: "{{ output_dir | expanduser }}/authorized_keys_without_comment"
+    mode: "0600"
+
+- name: Add a key beside the existing key without a comment
+  ansible.posix.authorized_key:
+    user: root
+    key: ssh-ed25519 DATA_ADDED added@example
+    state: present
+    manage_dir: false
+    path: "{{ output_dir | expanduser }}/authorized_keys_without_comment"
+  register: add_key_result
+
+- name: Read the authorized keys file
+  ansible.builtin.slurp:
+    src: "{{ output_dir | expanduser }}/authorized_keys_without_comment"
+  register: authorized_keys_content
+
+- name: Assert that the existing key did not gain trailing whitespace
+  ansible.builtin.assert:
+    that:
+      - add_key_result.changed
+      - (authorized_keys_content.content | b64decode) == expected_authorized_keys
+  vars:
+    expected_authorized_keys: |
+      ssh-ed25519 DATA_WITHOUT_COMMENT
+      ssh-ed25519 DATA_ADDED added@example
+
+- name: Add the same key again
+  ansible.posix.authorized_key:
+    user: root
+    key: ssh-ed25519 DATA_ADDED added@example
+    state: present
+    manage_dir: false
+    path: "{{ output_dir | expanduser }}/authorized_keys_without_comment"
+  register: repeat_key_result
+
+- name: Assert that the second run is unchanged
+  ansible.builtin.assert:
+    that:
+      - not repeat_key_result.changed

--- a/tests/integration/targets/authorized_key/tasks/main.yml
+++ b/tests/integration/targets/authorized_key/tasks/main.yml
@@ -32,6 +32,9 @@
 - name: Test for the management of comments with key
   ansible.builtin.import_tasks: comments.yml
 
+- name: Test serialization of keys without comments
+  ansible.builtin.import_tasks: empty_comment.yml
+
 - name: Test for specifying key as a path
   ansible.builtin.import_tasks: check_path.yml
 


### PR DESCRIPTION
##### SUMMARY

Fix `serialize()` so it appends the separating space and comment only when the comment is non-empty. Previously, rewriting an authorized keys file added trailing whitespace to existing keys without comments, producing misleading diffs.

Add integration coverage for the exact serialized content and second-run idempotency.

Fixes #750

Assisted-by: OpenAI Codex

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ansible.posix.authorized_key

##### ADDITIONAL INFORMATION

Validation performed with ansible-core 2.20.5 and Python 3.13:

```text
ansible-test integration authorized_key --allow-root --local
PLAY RECAP: ok=94 changed=37 unreachable=0 failed=0 skipped=1 rescued=0 ignored=1
# The ignored result is the target's existing intentional permission-denied test.

ansible-test sanity --local --python 3.13
exit status: 0
```
