### PR TITLE
fix(callback): align debug PLAY RECAP host columns

### DIFF
--- a/changelogs/fragments/778_debug_play_recap_alignment.yml
+++ b/changelogs/fragments/778_debug_play_recap_alignment.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - debug callback - align PLAY RECAP host stat columns for long inventory hostnames (https://github.com/ansible-collections/ansible.posix/pull/778).

--- a/plugins/callback/debug.py
+++ b/plugins/callback/debug.py
@@ -16,7 +16,18 @@ DOCUMENTATION = '''
       - set as stdout in configuration
 '''
 
+from ansible import constants as C
+from ansible import context
 from ansible.plugins.callback.default import CallbackModule as CallbackModule_default
+from ansible.utils.color import ANSIBLE_COLOR, colorize, stringc
+from ansible.utils.display import get_text_width
+
+
+def _text_width(text):
+    try:
+        return get_text_width(text)
+    except EnvironmentError:
+        return len(text)
 
 
 class CallbackModule(CallbackModule_default):  # pylint: disable=too-few-public-methods,no-init
@@ -51,3 +62,63 @@ class CallbackModule(CallbackModule_default):  # pylint: disable=too-few-public-
             result[key] = value
 
         return output
+
+    def _format_host_field(self, host, task_stats, width, color=True):
+        if color and ANSIBLE_COLOR:
+            if task_stats['failures'] != 0 or task_stats['unreachable'] != 0:
+                host_text = stringc(host, C.COLOR_ERROR)
+            elif task_stats['changed'] != 0:
+                host_text = stringc(host, C.COLOR_CHANGED)
+            else:
+                host_text = stringc(host, C.COLOR_OK)
+        else:
+            host_text = host
+
+        padding = max(0, width - _text_width(host))
+        return u"%s%s" % (host_text, u' ' * padding)
+
+    def _play_recap_line(self, host, task_stats, host_width, color=True):
+        return u"%s : %s %s %s %s %s %s %s" % (
+            self._format_host_field(host, task_stats, host_width, color=color),
+            colorize(u'ok', task_stats['ok'], C.COLOR_OK if color else None),
+            colorize(u'changed', task_stats['changed'], C.COLOR_CHANGED if color else None),
+            colorize(u'unreachable', task_stats['unreachable'], C.COLOR_UNREACHABLE if color else None),
+            colorize(u'failed', task_stats['failures'], C.COLOR_ERROR if color else None),
+            colorize(u'skipped', task_stats['skipped'], C.COLOR_SKIP if color else None),
+            colorize(u'rescued', task_stats['rescued'], C.COLOR_OK if color else None),
+            colorize(u'ignored', task_stats['ignored'], C.COLOR_WARN if color else None),
+        )
+
+    def v2_playbook_on_stats(self, stats):
+        self._display.banner("PLAY RECAP")
+
+        hosts = sorted(stats.processed.keys())
+        host_width = max((_text_width(h) for h in hosts), default=0)
+
+        for host in hosts:
+            task_stats = stats.summarize(host)
+            self._display.display(
+                self._play_recap_line(host, task_stats, host_width, color=True),
+                screen_only=True,
+            )
+            self._display.display(
+                self._play_recap_line(host, task_stats, host_width, color=False),
+                log_only=True,
+            )
+
+        self._display.display("", screen_only=True)
+
+        if stats.custom and self.get_option('show_custom_stats'):
+            self._display.banner("CUSTOM STATS: ")
+            for key in sorted(stats.custom.keys()):
+                if key == '_run':
+                    continue
+                self._display.display('\t%s: %s' % (key, self._dump_results(stats.custom[key], indent=1).replace('\n', '')))
+
+            if '_run' in stats.custom:
+                self._display.display("", screen_only=True)
+                self._display.display('\tRUN: %s' % self._dump_results(stats.custom['_run'], indent=1).replace('\n', ''))
+            self._display.display("", screen_only=True)
+
+        if context.CLIARGS['check'] and self.get_option('check_mode_markers'):
+            self._display.banner("DRY RUN")

--- a/tests/unit/plugins/callback/test_debug.py
+++ b/tests/unit/plugins/callback/test_debug.py
@@ -1,0 +1,86 @@
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+from ansible_collections.ansible.posix.tests.unit.compat import unittest
+from ansible.utils.display import get_text_width
+
+from ansible_collections.ansible.posix.plugins.callback.debug import CallbackModule
+
+
+class DebugPlayRecapTestCase(unittest.TestCase):
+
+    TASK_STATS = {
+        'ok': 4,
+        'changed': 0,
+        'unreachable': 0,
+        'failures': 0,
+        'skipped': 0,
+        'rescued': 0,
+        'ignored': 0,
+    }
+    # Reproducer from https://github.com/ansible-collections/ansible.posix/pull/778
+    HOSTS = [
+        'eic-guacamole-desktop-test-target',
+        'ext-korcsmaros-slk',
+        'short',
+    ]
+    CJK_HOST = '零一二三四五六七八九'
+
+    def setUp(self):
+        self.callback = CallbackModule()
+
+    def _stat_column(self, line):
+        return get_text_width(line[:line.index('ok=')])
+
+    def _host_width(self, hosts):
+        return max((get_text_width(host) for host in hosts), default=0)
+
+    def test_format_host_field_pads_short_hostname(self):
+        host_width = self._host_width(self.HOSTS)
+        field = self.callback._format_host_field('short', self.TASK_STATS, host_width, color=False)
+        self.assertEqual(get_text_width(field), host_width)
+        self.assertTrue(field.startswith('short'))
+
+    def test_play_recap_lines_align_colons_for_mixed_hostname_lengths(self):
+        host_width = self._host_width(self.HOSTS)
+        columns = [
+            self._stat_column(
+                self.callback._play_recap_line(host, self.TASK_STATS, host_width, color=False),
+            )
+            for host in self.HOSTS
+        ]
+        self.assertEqual(len(set(columns)), 1)
+
+    def test_play_recap_lines_align_colon_character_index_for_ascii_hostnames(self):
+        host_width = self._host_width(self.HOSTS)
+        columns = [
+            line.index(':')
+            for line in (
+                self.callback._play_recap_line(host, self.TASK_STATS, host_width, color=False)
+                for host in self.HOSTS
+            )
+        ]
+        self.assertEqual(len(set(columns)), 1)
+
+    def test_play_recap_longest_host_sets_field_width(self):
+        host_width = self._host_width(self.HOSTS)
+        longest = max(self.HOSTS, key=get_text_width)
+        field = self.callback._format_host_field(longest, self.TASK_STATS, host_width, color=False)
+        self.assertEqual(get_text_width(field), host_width)
+        self.assertEqual(field, longest)
+
+    def test_cjk_hostname_fits_len_budget_but_not_display_width(self):
+        self.assertEqual(len(self.CJK_HOST), 10)
+        self.assertEqual(get_text_width(self.CJK_HOST), 20)
+
+    def test_play_recap_lines_align_colons_with_cjk_hostname(self):
+        hosts = [self.CJK_HOST, 'short']
+        host_width = self._host_width(hosts)
+        columns = [
+            self._stat_column(
+                self.callback._play_recap_line(host, self.TASK_STATS, host_width, color=False),
+            )
+            for host in hosts
+        ]
+        self.assertEqual(len(set(columns)), 1)


### PR DESCRIPTION
## Summary

Split out of #773 at the maintainer's request. `ansible.posix.debug` PLAY RECAP rows used a fixed host field width, so shorter hostnames left the `:` (and the `ok=` column) at different positions. Pad each hostname to the longest name in the play so the stat columns line up.

## Output

Captured from `playbooks/test/callback-plugins.yml`.

Before (`ansible.posix` 2.2.2): `hostcolor()` pads to a fixed 37-character field. Shorter hostnames leave the `:` at varying columns (34, 27, 27 here). Hostnames longer than 37 characters extend past the field without padding shorter names to match.

```
PLAY RECAP *********************************************************************
eic-guacamole-desktop-test-target : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
ext-korcsmaros-slk         : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
short                      : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

After: host field is padded to the longest hostname in the play (colon at column 34 for all rows).

```
PLAY RECAP *********************************************************************
eic-guacamole-desktop-test-target : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
ext-korcsmaros-slk                : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
short                             : ok=4    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

## Test plan

- [x] Run a multi-host playbook with `stdout_callback=ansible.posix.debug`
- [x] Verify PLAY RECAP `ok=` columns align for short and long hostnames