### PR TITLE
[CI] Bump partner-certification-checker to v4.1.0

### DIFF
--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -32,4 +32,4 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v0.1
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v4.1.0

--- a/changelogs/fragments/780_ci_bump_certchecker.yml
+++ b/changelogs/fragments/780_ci_bump_certchecker.yml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - CI - Bump partner-certification-checker to v4.1.0 to fix ansible-lint compatibility.
+...


### PR DESCRIPTION
##### SUMMARY

Bump partner-certification-checker to v4.1.0

- Fixes ansible-lint import crash

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- ansible.posix

##### ADDITIONAL INFORMATION
```paste below
None
```
