### PR TITLE
[Backport][Stable-2] Backport #784

### DIFF
--- a/changelogs/fragments/783_profile_tasks_version_added.yml
+++ b/changelogs/fragments/783_profile_tasks_version_added.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - profile_tasks - fix incorrect ``version_added`` for ``datetime_format`` option(https://github.com/ansible-collections/ansible.posix/issues/783).
+...

--- a/plugins/callback/profile_tasks.py
+++ b/plugins/callback/profile_tasks.py
@@ -62,7 +62,7 @@ DOCUMENTATION = '''
         ini:
           - section: callback_profile_tasks
             key: datetime_format
-        version_added: 3.0.0
+        version_added: 2.2.0
       truncate_task_names:
         description:
           - Truncate long task names in the TASKS RECAP summary with an ellipsis so rows stay within the terminal width.


### PR DESCRIPTION
##### SUMMARY
Backport #784 

- Fixes #783
- Replaced version_added value with 2.2.0 for datetime_format


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

- ansible.posix.profile_tasks

##### ADDITIONAL INFORMATION
```paste below
None
```
