### PR TITLE
mount: Ensure backup_file also defined on fstab entry removal

### DIFF
--- a/changelogs/fragments/791_ensure_backup_file_defined_on_fstab_removal.yml
+++ b/changelogs/fragments/791_ensure_backup_file_defined_on_fstab_removal.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "Capture the name of the backup file even on fstab entry removal  (https://github.com/ansible-collections/ansible.posix/issues/533)."

--- a/plugins/modules/mount.py
+++ b/plugins/modules/mount.py
@@ -449,7 +449,7 @@ def unset_mount(module, args, backup=False):
         changed = True
 
     if changed and not module.check_mode:
-        write_fstab(module, to_write, args['fstab'])
+        args['backup_file'] = write_fstab(module, to_write, args['fstab'])
 
     if backup:
         return (args['name'], changed, lines)

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -210,7 +210,8 @@
 - name: Verify that the backup return value is empty when backups are not active
   ansible.builtin.assert:
     that:
-      - (bind_result_linux.backup_file == "") or (bind_result_freebsd.backup_file == "")
+      - (ansible_system == 'FreeBSD') or (bind_result_linux.backup_file == "")
+      - (ansible_system == 'Linux') or (bind_result_freebsd.backup_file == "")
   when: ansible_system in ('FreeBSD', 'Linux')
 
 # remount check mode
@@ -258,7 +259,8 @@
 - name: Verify that the backup return value is empty when checkmode is active
   ansible.builtin.assert:
     that:
-      - (bind_result_linux.backup_file == "") or (bind_result_freebsd.backup_file == "")
+      - (ansible_system == 'FreeBSD') or (bind_result_linux.backup_file == "")
+      - (ansible_system == 'Linux') or (bind_result_freebsd.backup_file == "")
   when: ansible_system in ('FreeBSD', 'Linux')
 
 # remount
@@ -301,7 +303,8 @@
 - name: Verify that the backup return value is not empty when backups are enabled
   ansible.builtin.assert:
     that:
-      - (bind_result_linux.backup_file | length > 0) or (bind_result_freebsd.backup_file | length > 0)
+      - (ansible_system == 'FreeBSD') or (bind_result_linux.backup_file | length > 0)
+      - (ansible_system == 'Linux') or (bind_result_freebsd.backup_file | length > 0)
   when: ansible_system in ('FreeBSD', 'Linux')
 
 # unmount check mode

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -154,7 +154,6 @@
     state: mounted
     fstype: None
     opts: bind
-    backup: false
   when: ansible_system == 'Linux'
   register: bind_result_linux
 
@@ -164,7 +163,6 @@
     name: '{{ output_dir }}/mount_dest'
     state: mounted
     fstype: nullfs
-    backup: false
   when: ansible_system == 'FreeBSD'
   register: bind_result_freebsd
 
@@ -189,6 +187,7 @@
     state: mounted
     fstype: None
     opts: bind
+    backup: false
   when: ansible_system == 'Linux'
   register: bind_result_linux
 
@@ -198,6 +197,7 @@
     name: '{{ output_dir }}/mount_dest'
     state: mounted
     fstype: nullfs
+    backup: false
   when: ansible_system == 'FreeBSD'
   register: bind_result_freebsd
 
@@ -234,6 +234,7 @@
     state: mounted
     fstype: nullfs
     opts: ro
+    backup: true
   when: ansible_system == 'FreeBSD'
   register: bind_result_freebsd
   check_mode: true
@@ -282,6 +283,7 @@
     state: mounted
     fstype: nullfs
     opts: ro
+    backup: true
   when: ansible_system == 'FreeBSD'
   register: bind_result_freebsd
 

--- a/tests/integration/targets/mount/tasks/main.yml
+++ b/tests/integration/targets/mount/tasks/main.yml
@@ -154,6 +154,7 @@
     state: mounted
     fstype: None
     opts: bind
+    backup: false
   when: ansible_system == 'Linux'
   register: bind_result_linux
 
@@ -163,6 +164,7 @@
     name: '{{ output_dir }}/mount_dest'
     state: mounted
     fstype: nullfs
+    backup: false
   when: ansible_system == 'FreeBSD'
   register: bind_result_freebsd
 
@@ -205,6 +207,12 @@
       - (ansible_system == 'Linux' and not bind_result_linux['changed']) or (ansible_system == 'FreeBSD' and not bind_result_freebsd['changed'])
   when: ansible_system in ('FreeBSD', 'Linux')
 
+- name: Verify that the backup return value is empty when backups are not active
+  ansible.builtin.assert:
+    that:
+      - (bind_result_linux.backup_file == "") or (bind_result_freebsd.backup_file == "")
+  when: ansible_system in ('FreeBSD', 'Linux')
+
 # remount check mode
 - name: Remount filesystem with different opts (Linux) (check mode)
   ansible.posix.mount:
@@ -213,6 +221,7 @@
     state: mounted
     fstype: None
     opts: bind,ro
+    backup: true
   when: ansible_system == 'Linux'
   register: bind_result_linux
   check_mode: true
@@ -246,6 +255,12 @@
     freebsd_and_changed: "{{ ansible_system == 'FreeBSD' and bind_result_freebsd['changed'] }}"
   when: ansible_system in ('FreeBSD', 'Linux')
 
+- name: Verify that the backup return value is empty when checkmode is active
+  ansible.builtin.assert:
+    that:
+      - (bind_result_linux.backup_file == "") or (bind_result_freebsd.backup_file == "")
+  when: ansible_system in ('FreeBSD', 'Linux')
+
 # remount
 - name: Remount filesystem with different opts (Linux)
   ansible.posix.mount:
@@ -254,6 +269,7 @@
     state: mounted
     fstype: None
     opts: bind,ro
+    backup: true
   when: ansible_system == 'Linux'
   register: bind_result_linux
 
@@ -282,11 +298,18 @@
       - 1 == remount_options.stdout_lines | length
   when: ansible_system in ('FreeBSD', 'Linux')
 
+- name: Verify that the backup return value is not empty when backups are enabled
+  ansible.builtin.assert:
+    that:
+      - (bind_result_linux.backup_file | length > 0) or (bind_result_freebsd.backup_file | length > 0)
+  when: ansible_system in ('FreeBSD', 'Linux')
+
 # unmount check mode
 - name: Unmount the bind mount (check mode)
   ansible.posix.mount:
     name: '{{ output_dir }}/mount_dest'
     state: absent
+    backup: true
   when: ansible_system in ('Linux', 'FreeBSD')
   register: unmount_result
   check_mode: true
@@ -311,11 +334,18 @@
       - dest_stat['stat']['exists']
   when: ansible_system in ('FreeBSD', 'Linux')
 
+- name: Verify that the backup return value is empty when checkmode is active
+  ansible.builtin.assert:
+    that:
+      - unmount_result.backup_file == ""
+  when: ansible_system in ('FreeBSD', 'Linux')
+
 # unmount
 - name: Unmount the bind mount
   ansible.posix.mount:
     name: '{{ output_dir }}/mount_dest'
     state: absent
+    backup: true
   when: ansible_system in ('Linux', 'FreeBSD')
   register: unmount_result
 
@@ -338,6 +368,13 @@
       - not mountpoint_stat['stat']['exists']
       - not dest_stat['stat']['exists']
   when: ansible_system in ('FreeBSD', 'Linux')
+
+- name: Verify that the backup return value is not empty when backups are enabled
+  ansible.builtin.assert:
+    that:
+      - unmount_result.backup_file | length > 0
+  when: ansible_system in ('FreeBSD', 'Linux')
+
 
 # unmount (absent_keep_mountpoint)
 - name: Bind mount a filesystem (Linux)
@@ -363,6 +400,7 @@
   ansible.posix.mount:
     name: '{{ output_dir }}/mount_dest'
     state: absent_keep_mountpoint
+    backup: false
   when: ansible_system in ('Linux', 'FreeBSD')
   register: unmount_result
 
@@ -385,6 +423,12 @@
       - unmount_result['changed']
       - mountpoint_stat['stat']['exists']
       - not dest_stat['stat']['exists']
+  when: ansible_system in ('FreeBSD', 'Linux')
+
+- name: Verify that the backup return value is empty when backups are disabled
+  ansible.builtin.assert:
+    that:
+      - unmount_result.backup_file == ""
   when: ansible_system in ('FreeBSD', 'Linux')
 
 # SWAP #############################################################


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Currently, when you remove an entry from /etc/fstab, it doesn't actually save the output of the write_fstab function (backup_file) anywhere.

For more advanced users who would like to pull the information on the backup they just created, they would be unable to do so without a hacky workaround.

My solution is just to define it in the unset_mount function like we do for the _set_mount_save_old function. If backup is set to false, then write_fstab will just return empty anyway (same as it would be otherwise).

Fixes #533 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
mount

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
First, I set up a Debian live-image VM, created my user and copied over my SSH keys, and then added my VM info to my hosts and inventory files. I also created a quick NFS on my host system and then put it into the fstab of my VM and did a mount -a.

Here is my playbook that I adapted from the original issue:
```yaml
- hosts: testhost
  gather_facts: true
  tasks:
  - name: Remove network shares from fstab
    become: true
    ansible.posix.mount:
      path: "{{ item.mount }}"
      src: "{{ item.device }}"
      state: absent_from_fstab
      backup: yes
    vars:
      nm: "{{ ansible_mounts | community.general.json_query('[?contains(fstype, `nfs`) || contains(fstype, `cifs`)]') }}"
    with_items: "{{ nm }}"
    when: (nm | length) > 0
    register: rem_nfs
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
Before change:
```paste below
mike @ blacktower : tmp > ansible-playbook test.yaml                                                                                                                         
Vault password:                                                                                                                                                              
                                                                                                                                                                             
PLAY [testhost] *************************************************************************************************************************************************************
                                                                                                                                                                             
TASK [Gathering Facts] ******************************************************************************************************************************************************
[WARNING]: Host 'testhost' is using the discovered Python interpreter at '/usr/bin/python3.13', but future installation of another Python interpreter could cause a different
 interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.21/reference_appendices/interpreter_discovery.html for more information.                          
ok: [testhost]                                                                                                                                                               
                                                                                                                                                                             
TASK [Remove network shares from fstab] *************************************************************************************************************************************
[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.                                                                      
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from an
sible-core version 2.24.                                                                                                                                                     
Origin: /tmp/test.yaml:12:11                                                                                                                                                 
                                                                                                                                                                             
10       backup: no                                                                                                                                                          
11     vars:                                                                                                                                                                 
12       nm: "{{ ansible_mounts | community.general.json_query('[?contains(fstype, `nfs`) || contains(fstype, `cifs`)...                                                     
             ^ column 11                                                                                                                                                     
                                                                                                                                                                             
Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.                                                                                                             
                                                                                                                                                                             
ok: [testhost] => (item={'mount': '/test', 'device': '192.168.1.163:/files', 'fstype': 'nfs4', 'options': 'rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,p
roto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.40,local_lock=none,addr=192.168.1.163', 'dump': 0, 'passno': 0, 'size_total': 6145209008128, 'size_available': 37
08320481280, 'block_size': 1048576, 'block_total': 5860528, 'block_available': 3536530, 'block_used': 2323998, 'inode_total': 0, 'inode_available': 0, 'inode_used': 0, 'uuid
': 'N/A'})                                                                                                                                                                   
changed: [testhost] => (item={'mount': '/mnt', 'device': '192.168.1.163:/files', 'fstype': 'nfs4', 'options': 'rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,ha
rd,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.40,local_lock=none,addr=192.168.1.163', 'dump': 0, 'passno': 0, 'size_total': 6145209008128, 'size_available'
: 3708320481280, 'block_size': 1048576, 'block_total': 5860528, 'block_available': 3536530, 'block_used': 2323998, 'inode_total': 0, 'inode_available': 0, 'inode_used': 0, '
uuid': 'N/A'})                                                                                                                                                               
                    
TASK [Print out the output] *************************************************************************************************************************************************
ok: [testhost] => {                                                                                                                                                          
    "rem_nfs": {                                                                                                                                                             
        "changed": true,                                                                                                                                                     
        "deprecations": [                                                                                                                                                    
            {                                                                                                                                                                
                "collection_name": "ansible.builtin",                                                                                                                        
                "deprecator": {                                                                                                                                              
                    "resolved_name": "ansible.builtin",                                                                                                                      
                    "type": null                                                                                                                                             
                },                                                                                                                                                           
                "msg": "INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change.",                                  
                "version": "2.24"                                                                                                                                            
            },                                                                                                                                                               
            {                                                                                                                                                                
                "collection_name": "ansible.builtin",                                                                                                                        
                "deprecator": {                                                                                                                                              
                    "resolved_name": "ansible.builtin",                                                                                                                      
                    "type": null                                                                                                                                             
                },                                                                                                                                                           
                "msg": "INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change.",                                  
                "version": "2.24"                                                                                                                                            
            }                                                                                                                                                                
        ],                                                                                                                                                                   
        "failed": false,                                                                                                                                                     
        "msg": "All items completed",                                                                                                                                        
        "results": [                                                                                                                                                         
            {                                                                                                                                                                
                "ansible_loop_var": "item",                                                                                                                                  
                "backup_file": "",                                                                                                                                           
                "boot": "yes",                                                                                                                                               
                "changed": false,                                                                                                                                            
                "deprecations": [                                                                                                                                            
                    {                                                                                                                                                        
                        "collection_name": "ansible.builtin",                                                                                                                
                        "deprecator": {                                                                                                                                      
                            "resolved_name": "ansible.builtin",                                                                                                              
                            "type": null  
                        },                                                                                                                                    00:28 [42/1099]
                        "msg": "INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change.",                          
                        "version": "2.24"                                                                                                                                    
                    }                                                                                                                                                        
                ],                                                                                                                                                           
                "dump": "0",                                                                                                                                                 
                "failed": false,                                                                                                                                             
                "fstab": "/etc/fstab",                                                                                                                                       
                "item": {                                                                                                                                                    
                    "block_available": 3536530,                                                                                                                              
                    "block_size": 1048576,                                                                                                                                   
                    "block_total": 5860528,                                                                                                                                  
                    "block_used": 2323998,                                                                                                                                   
                    "device": "192.168.1.163:/files",                                                                                                                        
                    "dump": 0,                                                                                                                                               
                    "fstype": "nfs4",                                                                                                                                        
                    "inode_available": 0,                                                                                                                                    
                    "inode_total": 0,                                                                                                                                        
                    "inode_used": 0,                                                                                                                                         
                    "mount": "/test",                                                                                                                                        
                    "options": "rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.40,local_lock=n
one,addr=192.168.1.163",                                                                                                                                                     
                    "passno": 0,                                                                                                                                             
                    "size_available": 3708320481280,                                                                                                                         
                    "size_total": 6145209008128,                                                                                                                             
                    "uuid": "N/A"                                                                                                                                            
                },                                                                                                                                                           
                "name": "/test",                                                                                                                                             
                "opts": "defaults",                                                                                                                                          
                "passno": "0",                                                                                                                                               
                "src": "192.168.1.163:/files"                                                                                                                                
            },                                                                                                                                                               
            {                                                                                                                                                                
                "ansible_loop_var": "item",                                                                                                                                  
                "backup_file": "",                                                                                                                                           
                "boot": "yes",                                                                                                                                               
                "changed": true,                                                                                                                                             
                "deprecations": [                                                                                                                                            
                    {                                                                                                                                                        
                        "collection_name": "ansible.builtin",                                                                                                                
                        "deprecator": {                                                                                                                                      
                            "resolved_name": "ansible.builtin",
                            "type": null
                        },
                        "msg": "INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change.",
                        "version": "2.24"
                    }
                ],
                "dump": "0",
                "failed": false,
                "fstab": "/etc/fstab",
                "item": {
                    "block_available": 3536530,
                    "block_size": 1048576,
                    "block_total": 5860528,
                    "block_used": 2323998,
                    "device": "192.168.1.163:/files",
                    "dump": 0,
                    "fstype": "nfs4",
                    "inode_available": 0,
                    "inode_total": 0,
                    "inode_used": 0,
                    "mount": "/mnt",
                    "options": "rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.40,local_lock=none,addr=192.168.1.163",
                    "passno": 0,
                    "size_available": 3708320481280,
                    "size_total": 6145209008128,
                    "uuid": "N/A"
                },
                "name": "/mnt",
                "opts": "defaults",
                "passno": "0",
                "src": "192.168.1.163:/files"
            }
        ]
    }
}

PLAY RECAP ******************************************************************************************************************************************************************
testhost                   : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0
```

After change:
```
mike @ blacktower : tmp > ansible-playbook test.yaml                                                                                                                         
Vault password:                                                                                                                                                              
                                                                                                                                                                             
PLAY [testhost] *************************************************************************************************************************************************************
                                                                                                                                                                             
TASK [Gathering Facts] ******************************************************************************************************************************************************
[WARNING]: Host 'testhost' is using the discovered Python interpreter at '/usr/bin/python3.13', but future installation of another Python interpreter could cause a different
 interpreter to be discovered. See https://docs.ansible.com/ansible-core/2.21/reference_appendices/interpreter_discovery.html for more information.                          
ok: [testhost]                                                                                                                                                               
                                                                                                                                                                             
TASK [Remove network shares from fstab] *************************************************************************************************************************************
[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.                                                                      
[DEPRECATION WARNING]: INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change. This feature will be removed from an
sible-core version 2.24.                                                                                                                                                     
Origin: /tmp/test.yaml:12:11 
                                                                                                                                                          
10       backup: true                                                                                                                                                        
11     vars:                                                                                                                                                                 
12       nm: "{{ ansible_mounts | community.general.json_query('[?contains(fstype, `nfs`) || contains(fstype, `cifs`)...                                                     
             ^ column 11                                                                                                                                                     
                                                                                                                                                                             
Use `ansible_facts["fact_name"]` (no `ansible_` prefix) instead.                                                                                                             
                                                                                                                                                                             
changed: [testhost] => (item={'mount': '/mnt', 'device': '192.168.1.163:/files', 'fstype': 'nfs4', 'options': 'rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,ha
rd,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.40,local_lock=none,addr=192.168.1.163', 'dump': 0, 'passno': 0, 'size_total': 6145209008128, 'size_available'
: 3708320481280, 'block_size': 1048576, 'block_total': 5860528, 'block_available': 3536530, 'block_used': 2323998, 'inode_total': 0, 'inode_available': 0, 'inode_used': 0, '
uuid': 'N/A'})                                                                                                                                                               
                                                                                                                                                                             
TASK [Print out the output] *************************************************************************************************************************************************
ok: [testhost] => {                                                                                                                                                          
    "rem_nfs": {                                                                                                                                                             
        "changed": true,                                                                                                                                                     
        "deprecations": [                                                                                                                                                    
            {                                                                                                                                                                
                "collection_name": "ansible.builtin",                                                                                                                        
                "deprecator": {                                                                                                                                              
                    "resolved_name": "ansible.builtin",                                                                                                                      
                    "type": null                                                                                                                                             
                },                                                                                                                                                           
                "msg": "INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change.",                                  
                "version": "2.24"                                                                                                                                            
            }                                                                                                                                                                
        ],                                                                                                                                                                   
        "failed": false,                                                                                                                                                     
        "msg": "All items completed",                                                                                                                                        
        "results": [                                                                                                                                                         
            {                                                                                                                                                                
                "ansible_loop_var": "item",                                                                                                                                  
                "backup_file": "/etc/fstab.10195.2026-09-10@04:59:56~",                                                                                                      
                "boot": "yes",                                                                                                                                               
                "changed": true,                                                                                                                                             
                "deprecations": [                                                                                                                                            
                    {                                                                                                                                                        
                        "collection_name": "ansible.builtin",                                                                                                                
                        "deprecator": {                                                                                                                                      
                            "resolved_name": "ansible.builtin",     
                            "type": null
                        },
                        "msg": "INJECT_FACTS_AS_VARS default to `True` is deprecated, top-level facts will not be auto injected after the change.",
                        "version": "2.24"
                    }
                ],
                "dump": "0",
                "failed": false,
                "fstab": "/etc/fstab",
                "item": {
                    "block_available": 3536530,
                    "block_size": 1048576,
                    "block_total": 5860528,
                    "block_used": 2323998,
                    "device": "192.168.1.163:/files",
                    "dump": 0,
                    "fstype": "nfs4",
                    "inode_available": 0,
                    "inode_total": 0,
                    "inode_used": 0,
                    "mount": "/mnt",
                    "options": "rw,relatime,vers=4.2,rsize=1048576,wsize=1048576,namlen=255,hard,proto=tcp,timeo=600,retrans=2,sec=sys,clientaddr=192.168.122.40,local_lock=n
one,addr=192.168.1.163",
                    "passno": 0,
                    "size_available": 3708320481280,
                    "size_total": 6145209008128,
                    "uuid": "N/A"
                },
                "name": "/mnt",
                "opts": "defaults",
                "passno": "0",
                "src": "192.168.1.163:/files"
            }
        ]
    }
}

PLAY RECAP ******************************************************************************************************************************************************************
testhost                   : ok=3    changed=1    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0  
```